### PR TITLE
udpate config

### DIFF
--- a/dry-run/dr-eslint-config-sc-react/tests/.eslintrc.tsx.js
+++ b/dry-run/dr-eslint-config-sc-react/tests/.eslintrc.tsx.js
@@ -5,7 +5,8 @@ module.exports = {
   extends: [
     "plugin:@stylistic/recommended-extends",
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended-type-checked",
+    "plugin:@typescript-eslint/strict-type-checked",
+    "plugin:@typescript-eslint/stylistic-type-checked",
     "plugin:unicorn/recommended",
     "plugin:react/jsx-runtime",
     "plugin:react/recommended",
@@ -18,7 +19,8 @@ module.exports = {
   },
   parser: "@typescript-eslint/parser",
   rules: {
-    ...eslintConfigSCTs.configs.customRecords[0].rules,
+    ...eslintConfigSCTs.configs.customRecords[1].rules,
+    ...eslintConfigSCReact.configs.customRecords[0].rules,
     ...eslintConfigSCReact.configs.customRecords[1].rules,
     ...eslintConfigSCReact.configs.customRecordsWithTypescript[0].rules,
     ...eslintConfigSCReact.configs.resetRecordsForStylistic[0].rules,

--- a/dry-run/dr-eslint-config-sc-react/tests/eslint.config.tsx.mjs
+++ b/dry-run/dr-eslint-config-sc-react/tests/eslint.config.tsx.mjs
@@ -4,9 +4,13 @@ import typescriptEslintParser from "@typescript-eslint/parser"
 
 export default [
   ...eslintConfigSCTs.configs.baseRecords1,
+  ...eslintConfigSCReact.configs.baseRecords1,
   ...eslintConfigSCReact.configs.baseRecords2,
+
+  ...eslintConfigSCTs.configs.customRecords,
   ...eslintConfigSCReact.configs.customRecords,
   ...eslintConfigSCReact.configs.customRecordsWithTypescript,
+
   ...eslintConfigSCReact.configs.resetRecordsForStylistic,
   {
     languageOptions: {

--- a/packages/eslint-config-react/README.md
+++ b/packages/eslint-config-react/README.md
@@ -42,8 +42,11 @@ export default [
   ...eslintConfigSCTs.configs.baseRecords1,
   ...eslintConfigSCReact.configs.baseRecords1,
   ...eslintConfigSCReact.configs.baseRecords2,
+
+  ...eslintConfigSCTs.configs.customRecords,
   ...eslintConfigSCReact.configs.customRecords,
   ...eslintConfigSCReact.configs.customRecordsWithTypescript, // This is the custom config for typescript of eslint-config-sc-react
+
   ...eslintConfigSCReact.configs.resetRecordsForStylistic,
 ]
 ```
@@ -88,7 +91,8 @@ module.exports = {
   extends: [
     "plugin:@stylistic/recommended-extends",
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended-type-checked",
+    "plugin:@typescript-eslint/strict-type-checked",
+    "plugin:@typescript-eslint/stylistic-type-checked",
     "plugin:unicorn/recommended",
     "plugin:react/jsx-runtime",
     "plugin:react/recommended",
@@ -96,10 +100,10 @@ module.exports = {
     "airbnb/hooks",
   ],
   rules: {
+    ...eslintConfigSCTs.configs.customRecords[1].rules,
     ...eslintConfigSCReact.configs.customRecords[0].rules,
     ...eslintConfigSCReact.configs.customRecords[1].rules,
     ...eslintConfigSCReact.configs.customRecordsWithTypescript[0].rules,  // This is the custom config for typescript of eslint-config-sc-react
-    ...eslintConfigSCTs.configs.customRecords[0].rules,
     ...eslintConfigSCReact.configs.resetRecordsForStylistic[0].rules,
   },
 }

--- a/packages/eslint-config-react/src/shared/config/rules/typescriptRules/index.ts
+++ b/packages/eslint-config-react/src/shared/config/rules/typescriptRules/index.ts
@@ -1,7 +1,9 @@
 import { reactRules as pluginReactRules } from "./rules/reactRules"
+import { typescriptEslintRules } from "./rules/typescriptEslint"
 
 import type { EslintRules } from "../../../../libs/shared-for-config/types/EslintRules"
 
 export const typescriptRules = {
   ...pluginReactRules,
+  ...typescriptEslintRules,
 } as const satisfies EslintRules

--- a/packages/eslint-config-react/src/shared/config/rules/typescriptRules/rules/typescriptEslint/index.ts
+++ b/packages/eslint-config-react/src/shared/config/rules/typescriptRules/rules/typescriptEslint/index.ts
@@ -1,0 +1,7 @@
+import { namingConvention } from "./options/namingConvention"
+
+import type { EslintRules } from "../../../../../../libs/shared-for-config/types/EslintRules"
+
+export const typescriptEslintRules = {
+  "@typescript-eslint/naming-convention": namingConvention,
+} as const satisfies EslintRules

--- a/packages/eslint-config-react/src/shared/config/rules/typescriptRules/rules/typescriptEslint/options/namingConvention/index.ts
+++ b/packages/eslint-config-react/src/shared/config/rules/typescriptRules/rules/typescriptEslint/options/namingConvention/index.ts
@@ -1,0 +1,46 @@
+import { SEVERITY } from "../../../../../../../../libs/shared-for-config/constants/SEVERITY"
+
+import type {
+  EslintRuleLevelAndOptions,
+} from "../../../../../../../../libs/shared-for-config/types/EslintRuleLevelAndOptions"
+
+export const namingConvention = [
+  SEVERITY.ERROR,
+
+  // Options based: https://typescript-eslint.io/rules/naming-convention/#options
+  {
+    selector: "default",
+
+    format: ["camelCase"],
+    leadingUnderscore: "allow",
+    trailingUnderscore: "allow",
+  },
+
+  {
+    selector: "import",
+
+    format: ["camelCase", "PascalCase"],
+  },
+
+  {
+    selector: "variable",
+
+    format: ["camelCase", "UPPER_CASE", "PascalCase"],
+    leadingUnderscore: "allow",
+    trailingUnderscore: "allow",
+  },
+
+  {
+    selector: "function",
+
+    format: ["camelCase", "PascalCase"],
+    leadingUnderscore: "allow",
+    trailingUnderscore: "allow",
+  },
+
+  {
+    selector: "typeLike",
+
+    format: ["PascalCase"],
+  },
+] as const satisfies EslintRuleLevelAndOptions


### PR DESCRIPTION
## features
- override `@typescript-eslint/naming-convention` for react
  - add PascalCase into variable, function