### PR TITLE
adjust naming convention/adjust

### DIFF
--- a/packages/eslint-config-react/src/shared/config/rules/typescriptRules/rules/typescriptEslint/options/namingConvention/index.ts
+++ b/packages/eslint-config-react/src/shared/config/rules/typescriptRules/rules/typescriptEslint/options/namingConvention/index.ts
@@ -31,6 +31,14 @@ export const namingConvention = [
   },
 
   {
+    selector: "objectLiteralProperty",
+
+    format: ["camelCase", "UPPER_CASE"],
+    leadingUnderscore: "allow",
+    trailingUnderscore: "forbid",
+  },
+
+  {
     selector: "function",
 
     format: ["camelCase", "PascalCase"],

--- a/packages/eslint-config-ts/src/shared/config/rules/baseRules/rules/typescriptEslintRules/index.ts
+++ b/packages/eslint-config-ts/src/shared/config/rules/baseRules/rules/typescriptEslintRules/index.ts
@@ -1,6 +1,7 @@
 import { arrayType } from "./options/arrayType"
 import { consistentTypeAssertions } from "./options/consistentTypeAssertions"
 import { consistentTypeImports } from "./options/consistentTypeImports"
+import { namingConvention } from "./options/namingConvention"
 import { noConfusingVoidExpression } from "./options/noConfusingVoidExpression"
 import { noUnnecessaryBooleanLiteralCompare } from "./options/noUnnecessaryBooleanLiteralCompare"
 import { noUnnecessaryCondition } from "./options/noUnnecessaryCondition"
@@ -21,7 +22,7 @@ export const typescriptEslintRules = {
   "@typescript-eslint/consistent-type-imports": consistentTypeImports,
   "@typescript-eslint/explicit-module-boundary-types": SEVERITY.OFF,
   "@typescript-eslint/max-params": SEVERITY.WARN,
-  "@typescript-eslint/naming-convention": SEVERITY.ERROR,
+  "@typescript-eslint/naming-convention": namingConvention,
   "@typescript-eslint/no-confusing-void-expression": noConfusingVoidExpression,
   "@typescript-eslint/no-empty-function": SEVERITY.ERROR,
   "@typescript-eslint/no-empty-interface": SEVERITY.WARN,

--- a/packages/eslint-config-ts/src/shared/config/rules/baseRules/rules/typescriptEslintRules/options/namingConvention/index.ts
+++ b/packages/eslint-config-ts/src/shared/config/rules/baseRules/rules/typescriptEslintRules/options/namingConvention/index.ts
@@ -1,0 +1,46 @@
+import { SEVERITY } from "../../../../../../../../libs/shared-for-config/constants/SEVERITY"
+
+import type {
+  EslintRuleLevelAndOptions,
+} from "../../../../../../../../libs/shared-for-config/types/EslintRuleLevelAndOptions"
+
+export const namingConvention = [
+  SEVERITY.ERROR,
+
+  // Options based: https://typescript-eslint.io/rules/naming-convention/#options
+  {
+    selector: "default",
+
+    format: ["camelCase"],
+    leadingUnderscore: "allow",
+    trailingUnderscore: "forbid",
+  },
+
+  {
+    selector: "import",
+
+    format: ["camelCase", "PascalCase"],
+  },
+
+  {
+    selector: ["variable", "objectLiteralProperty"],
+
+    format: ["camelCase", "UPPER_CASE"],
+    leadingUnderscore: "allow",
+    trailingUnderscore: "forbid",
+  },
+
+  {
+    selector: "function",
+
+    format: ["camelCase"],
+    leadingUnderscore: "allow",
+    trailingUnderscore: "forbid",
+  },
+
+  {
+    selector: "typeLike",
+
+    format: ["PascalCase"],
+  },
+] as const satisfies EslintRuleLevelAndOptions


### PR DESCRIPTION
## eslint-config-ts
- include UPPER_CASE into objectLiteralProperty

## eslint-config-react
- include UPPER_CASE into objectLiteralProperty