### PR TITLE
fixes

### DIFF
--- a/dry-run/dr-eslint-config-sc-js/tests/flat/js-test.js
+++ b/dry-run/dr-eslint-config-sc-js/tests/flat/js-test.js
@@ -239,3 +239,6 @@ const object3 = {
   "a": 1,
   "a-a": 1,
 }
+
+// eslint-disable-next-line @stylistic/arrow-parens
+const arrowFunction1 = a => a

--- a/dry-run/dr-eslint-config-sc-js/tests/flat/js-test.js
+++ b/dry-run/dr-eslint-config-sc-js/tests/flat/js-test.js
@@ -234,3 +234,8 @@ if(Math.random()){
 // eslint-disable-next-line @stylistic/brace-style
 }
 else console.log("")
+
+const object3 = {
+  "a": 1,
+  "a-a": 1,
+}

--- a/dry-run/dr-eslint-config-sc-js/tests/legacy/js-test.js
+++ b/dry-run/dr-eslint-config-sc-js/tests/legacy/js-test.js
@@ -239,3 +239,6 @@ const object3 = {
   "a": 1,
   "a-a": 1,
 }
+
+// eslint-disable-next-line @stylistic/arrow-parens
+const arrowFunction1 = a => a

--- a/dry-run/dr-eslint-config-sc-js/tests/legacy/js-test.js
+++ b/dry-run/dr-eslint-config-sc-js/tests/legacy/js-test.js
@@ -234,3 +234,8 @@ if(Math.random()){
 // eslint-disable-next-line @stylistic/brace-style
 }
 else console.log("")
+
+const object3 = {
+  "a": 1,
+  "a-a": 1,
+}

--- a/dry-run/dr-eslint-config-sc-react/tests/.eslintrc.tsx.js
+++ b/dry-run/dr-eslint-config-sc-react/tests/.eslintrc.tsx.js
@@ -23,6 +23,6 @@ module.exports = {
     ...eslintConfigSCReact.configs.customRecords[0].rules,
     ...eslintConfigSCReact.configs.customRecords[1].rules,
     ...eslintConfigSCReact.configs.customRecordsWithTypescript[0].rules,
-    ...eslintConfigSCReact.configs.resetRecordsForStylistic[0].rules,
+    ...eslintConfigSCReact.configs.resetRecordForStylistic.rules,
   },
 }

--- a/dry-run/dr-eslint-config-sc-react/tests/eslint.config.tsx.mjs
+++ b/dry-run/dr-eslint-config-sc-react/tests/eslint.config.tsx.mjs
@@ -8,10 +8,10 @@ export default [
   eslintConfigSCReact.configs.baseRecords2,
 
   eslintConfigSCTs.configs.customRecords,
-  eslintConfigSCReact.configs.customRecords,
-  eslintConfigSCReact.configs.customRecordsWithTypescript,
+  eslintConfigSCReact.configs.customRecord,
+  eslintConfigSCReact.configs.customRecordWithTypescript,
 
-  eslintConfigSCReact.configs.resetRecordsForStylistic,
+  eslintConfigSCReact.configs.resetRecordForStylistic,
   {
     languageOptions: {
       parserOptions: {

--- a/dry-run/dr-eslint-config-sc-react/tests/flat/jsx-test.jsx
+++ b/dry-run/dr-eslint-config-sc-react/tests/flat/jsx-test.jsx
@@ -82,3 +82,10 @@ export const ReactTest4 = () => (
   // eslint-disable-next-line react/jsx-props-no-spreading
   <ReactTest3 {...reactTest3Props} />
 )
+
+const text1ForReactTest5 = "jsx-one-expression-per-line"
+const text2ForReactTest5 = "jsx-one-expression-per-line"
+export const ReactTest5 = () => (
+  // eslint-disable-next-line @stylistic/jsx-one-expression-per-line
+  <div>{text1ForReactTest5}{text2ForReactTest5}</div>
+)

--- a/dry-run/dr-eslint-config-sc-react/tests/flat/tsx-test.tsx
+++ b/dry-run/dr-eslint-config-sc-react/tests/flat/tsx-test.tsx
@@ -105,3 +105,10 @@ const reactTest3Props = {
 /* eslint-enable sort-keys */
 
 export const ReactTest4 = () => <ReactTest3 {...reactTest3Props} />
+
+const text1ForReactTest5 = "jsx-one-expression-per-line"
+const text2ForReactTest5 = "jsx-one-expression-per-line"
+export const ReactTest5 = () => (
+  // eslint-disable-next-line @stylistic/jsx-one-expression-per-line
+  <div>{text1ForReactTest5}{text2ForReactTest5}</div>
+)

--- a/dry-run/dr-eslint-config-sc-react/tests/legacy/jsx-test.jsx
+++ b/dry-run/dr-eslint-config-sc-react/tests/legacy/jsx-test.jsx
@@ -82,3 +82,10 @@ export const ReactTest4 = () => (
   // eslint-disable-next-line react/jsx-props-no-spreading
   <ReactTest3 {...reactTest3Props} />
 )
+
+const text1ForReactTest5 = "jsx-one-expression-per-line"
+const text2ForReactTest5 = "jsx-one-expression-per-line"
+export const ReactTest5 = () => (
+  // eslint-disable-next-line @stylistic/jsx-one-expression-per-line
+  <div>{text1ForReactTest5}{text2ForReactTest5}</div>
+)

--- a/dry-run/dr-eslint-config-sc-react/tests/legacy/tsx-test.tsx
+++ b/dry-run/dr-eslint-config-sc-react/tests/legacy/tsx-test.tsx
@@ -106,3 +106,10 @@ const reactTest3Props = {
 /* eslint-enable sort-keys */
 
 export const ReactTest4 = () => <ReactTest3 {...reactTest3Props} />
+
+const text1ForReactTest5 = "jsx-one-expression-per-line"
+const text2ForReactTest5 = "jsx-one-expression-per-line"
+export const ReactTest5 = () => (
+  // eslint-disable-next-line @stylistic/jsx-one-expression-per-line
+  <div>{text1ForReactTest5}{text2ForReactTest5}</div>
+)

--- a/packages/eslint-config-jest/src/shared/config/records/overrideJavascriptRecord/index.ts
+++ b/packages/eslint-config-jest/src/shared/config/records/overrideJavascriptRecord/index.ts
@@ -1,6 +1,7 @@
 import { FILES } from "../../../const/FILES"
 import { PACKAGE_NAME } from "../../../const/PACKAGE_NAME"
 import { overrideEslintRules } from "../../rules/overrideEslintRules"
+import { overrideImportRules } from "../../rules/overrideImportRules"
 
 import type { EslintFlatConfig } from "../../../../libs/shared-for-config/types/EslintFlatConfig"
 
@@ -10,5 +11,6 @@ export const overrideJavascriptRecord = {
   files: FILES.JS,
   rules: {
     ...overrideEslintRules,
+    ...overrideImportRules,
   },
 } as const satisfies EslintFlatConfig

--- a/packages/eslint-config-jest/src/shared/config/records/overrideTypescriptRecord/index.ts
+++ b/packages/eslint-config-jest/src/shared/config/records/overrideTypescriptRecord/index.ts
@@ -1,6 +1,7 @@
 import { FILES } from "../../../const/FILES"
 import { PACKAGE_NAME } from "../../../const/PACKAGE_NAME"
 import { overrideEslintRules } from "../../rules/overrideEslintRules"
+import { overrideImportRules } from "../../rules/overrideImportRules"
 import { overrideTypescriptEslintRules } from "../../rules/overrideTypescriptEslintRules"
 
 import type { EslintFlatConfig } from "../../../../libs/shared-for-config/types/EslintFlatConfig"
@@ -11,6 +12,7 @@ export const overrideTypescriptRecord = {
   files: FILES.TS,
   rules: {
     ...overrideEslintRules,
+    ...overrideImportRules,
     ...overrideTypescriptEslintRules,
   },
 } as const satisfies EslintFlatConfig

--- a/packages/eslint-config-jest/src/shared/config/rules/overrideImportRules/index.ts
+++ b/packages/eslint-config-jest/src/shared/config/rules/overrideImportRules/index.ts
@@ -1,0 +1,7 @@
+import { SEVERITY } from "../../../../libs/shared-for-config/constants/SEVERITY"
+
+import type { EslintRules } from "../../../../libs/shared-for-config/types/EslintRules"
+
+export const overrideImportRules = {
+  "import/no-extraneous-dependencies": SEVERITY.OFF,
+} as const satisfies EslintRules

--- a/packages/eslint-config-js/src/shared/config/rules/baseRules/rules/stylisticRules/index.ts
+++ b/packages/eslint-config-js/src/shared/config/rules/baseRules/rules/stylisticRules/index.ts
@@ -4,6 +4,7 @@ import { SEVERITY } from "../../../../../../libs/shared-for-config/constants/SEV
 import type { EslintRules } from "../../../../../../libs/shared-for-config/types/EslintRules"
 
 export const stylisticRules = {
+  "@stylistic/arrow-parens": [SEVERITY.ERROR, "always"],
   "@stylistic/brace-style": [SEVERITY.ERROR, "1tbs"],
   "@stylistic/max-len": maxLength,
   "@stylistic/quotes": [SEVERITY.ERROR, "double", { avoidEscape: true }],

--- a/packages/eslint-config-js/src/shared/config/rules/resetRulesForStylistic/rules/eslintRules/index.ts
+++ b/packages/eslint-config-js/src/shared/config/rules/resetRulesForStylistic/rules/eslintRules/index.ts
@@ -10,6 +10,7 @@ export const eslintRules = {
   "max-len": SEVERITY.OFF,
   "no-multi-spaces": SEVERITY.OFF,
   "object-curly-newline": SEVERITY.OFF,
+  "quote-props": SEVERITY.OFF,
   "quotes": SEVERITY.OFF,
   "semi": SEVERITY.OFF,
   "space-before-blocks": SEVERITY.OFF,

--- a/packages/eslint-config-js/src/shared/config/rules/resetRulesForStylistic/rules/eslintRules/index.ts
+++ b/packages/eslint-config-js/src/shared/config/rules/resetRulesForStylistic/rules/eslintRules/index.ts
@@ -3,6 +3,7 @@ import { SEVERITY } from "../../../../../../libs/shared-for-config/constants/SEV
 import type { EslintRules } from "../../../../../../libs/shared-for-config/types/EslintRules"
 
 export const eslintRules = {
+  "arrow-parens": SEVERITY.OFF,
   "brace-style": SEVERITY.OFF,
   "comma-dangle": SEVERITY.OFF,
   "key-spacing": SEVERITY.OFF,

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -50,7 +50,8 @@
   },
   "dependencies": {
     "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-sc-js": "^0.0.7"
+    "eslint-config-sc-js": "^0.0.7",
+    "globals": "^15.6.0"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "^2.2.2",

--- a/packages/eslint-config-react/src/legacyConfig/index.ts
+++ b/packages/eslint-config-react/src/legacyConfig/index.ts
@@ -1,6 +1,7 @@
 import eslintConfigSCJs from "eslint-config-sc-js"
 
 import { baseRules } from "../shared/config/rules/baseRules"
+import { resetRulesForStylistic } from "../shared/config/rules/resetRulesForStylistic"
 import { typescriptRules } from "../shared/config/rules/typescriptRules"
 
 import type { EslintLegacyConfig } from "../libs/shared-for-config/types/EslintLegacyConfig"
@@ -21,6 +22,7 @@ export const legacyConfig = {
   rules: {
     ...eslintConfigSCJs.configs.customRecords[ZERO].rules,
     ...baseRules,
+    ...resetRulesForStylistic,
     ...eslintConfigSCJs.configs.resetRecordsForStylistic[ZERO].rules,
   },
 

--- a/packages/eslint-config-react/src/shared/config/languageOptions/index.ts
+++ b/packages/eslint-config-react/src/shared/config/languageOptions/index.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line import/no-unresolved
+import globals from "globals"
+
+export const languageOptions = {
+  languageOptions: {
+    globals: {
+      ...globals.browser,
+    },
+  },
+} as const

--- a/packages/eslint-config-react/src/shared/config/records/initialRecord/index.ts
+++ b/packages/eslint-config-react/src/shared/config/records/initialRecord/index.ts
@@ -1,10 +1,12 @@
 import eslintConfigSCJs from "eslint-config-sc-js"
 
 import { PACKAGE_NAME } from "../../../constants/PACKAGE_NAME"
+import { languageOptions } from "../../languageOptions"
 
 import type { EslintFlatConfig } from "../../../../libs/shared-for-config/types/EslintFlatConfig"
 
 export const initialRecord = {
   ...eslintConfigSCJs.configs.initialRecord,
+  ...languageOptions,
   name: `${PACKAGE_NAME}/initialRecord`,
 } as const satisfies EslintFlatConfig

--- a/packages/eslint-config-react/src/shared/config/records/reactRecords/index.ts
+++ b/packages/eslint-config-react/src/shared/config/records/reactRecords/index.ts
@@ -7,5 +7,5 @@ export const reactRecords = [
   {
     name: `${PACKAGE_NAME}/reactRecords`,
   },
-  ...getCompatExtends("plugin:react/jsx-runtime", "plugin:react/recommended"),
+  ...getCompatExtends("plugin:react/recommended", "plugin:react/jsx-runtime"),
 ] as const satisfies EslintFlatConfig[]

--- a/packages/eslint-config-react/src/shared/config/records/resetRecordForStylistic/index.ts
+++ b/packages/eslint-config-react/src/shared/config/records/resetRecordForStylistic/index.ts
@@ -1,10 +1,14 @@
 import eslintConfigSCJs from "eslint-config-sc-js"
 
 import { PACKAGE_NAME } from "../../../constants/PACKAGE_NAME"
+import { resetRulesForStylistic } from "../../rules/resetRulesForStylistic"
 
 import type { EslintFlatConfig } from "../../../../libs/shared-for-config/types/EslintFlatConfig"
 
 export const resetRecordForStylistic = {
-  ...eslintConfigSCJs.configs.resetRecordForStylistic,
   name: `${PACKAGE_NAME}/resetRecordForStylistic`,
+  rules: {
+    ...eslintConfigSCJs.configs.resetRecordForStylistic.rules,
+    ...resetRulesForStylistic,
+  },
 } as const satisfies EslintFlatConfig

--- a/packages/eslint-config-react/src/shared/config/rules/resetRulesForStylistic/index.ts
+++ b/packages/eslint-config-react/src/shared/config/rules/resetRulesForStylistic/index.ts
@@ -1,0 +1,7 @@
+import { SEVERITY } from "../../../../libs/shared-for-config/constants/SEVERITY"
+
+import type { EslintRules } from "../../../../libs/shared-for-config/types/EslintRules"
+
+export const resetRulesForStylistic = {
+  "react/jsx-one-expression-per-line": SEVERITY.OFF,
+} as const satisfies EslintRules

--- a/packages/eslint-config-storybook/src/shared/config/rules/overrideEslintRules/index.ts
+++ b/packages/eslint-config-storybook/src/shared/config/rules/overrideEslintRules/index.ts
@@ -7,6 +7,7 @@ export const overrideEslintRules = {
   "complexity": SEVERITY.OFF,
   "max-lines": [SEVERITY.WARN, 200],
   "max-nested-callbacks": [SEVERITY.ERROR, 5],
+  "max-statements": [SEVERITY.ERROR, 30],
   "no-console": SEVERITY.OFF,
   "no-magic-numbers": SEVERITY.OFF,
   "no-undefined": SEVERITY.OFF,

--- a/packages/eslint-config-storybook/src/shared/config/rules/overrideImportRules/index.ts
+++ b/packages/eslint-config-storybook/src/shared/config/rules/overrideImportRules/index.ts
@@ -4,4 +4,5 @@ import type { EslintRules } from "../../../../libs/shared-for-config/types/Eslin
 
 export const overrideImportRules = {
   "import/no-default-export": SEVERITY.OFF,
+  "import/no-extraneous-dependencies": SEVERITY.OFF,
 } as const satisfies EslintRules

--- a/packages/eslint-config-ts/package.json
+++ b/packages/eslint-config-ts/package.json
@@ -62,6 +62,7 @@
     "cspell": "^8.9.1",
     "editorconfig-checker": "^5.1.8",
     "eslint": "^8.57.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "fixpack": "^4.0.0",
     "npm-run-all2": "^6.2.0",
     "prettier": "^3.3.2",

--- a/packages/eslint-config-ts/src/shared/config/rules/baseRules/rules/eslintRules/index.ts
+++ b/packages/eslint-config-ts/src/shared/config/rules/baseRules/rules/eslintRules/index.ts
@@ -9,6 +9,7 @@ export const eslintRules = {
   "no-magic-numbers": SEVERITY.OFF,
   "no-multiple-empty-lines": SEVERITY.OFF,
   "no-shadow": SEVERITY.OFF,
+  "no-unused-expressions": SEVERITY.OFF,
   "no-unused-vars": SEVERITY.OFF,
   "no-use-before-define": SEVERITY.OFF,
   "prefer-destructuring": SEVERITY.OFF,

--- a/packages/eslint-config-ts/src/shared/config/rules/baseRules/rules/eslintRules/index.ts
+++ b/packages/eslint-config-ts/src/shared/config/rules/baseRules/rules/eslintRules/index.ts
@@ -4,6 +4,7 @@ import type { EslintRules } from "../../../../../../libs/shared-for-config/types
 
 export const eslintRules = {
   "default-case": SEVERITY.OFF, // check by @typescript-eslint/switch-exhaustiveness-check
+  "dot-notation": SEVERITY.OFF,
   "max-params": SEVERITY.OFF,
   "no-magic-numbers": SEVERITY.OFF,
   "no-multiple-empty-lines": SEVERITY.OFF,

--- a/packages/eslint-config-ts/src/shared/config/settings/importSettings/index.ts
+++ b/packages/eslint-config-ts/src/shared/config/settings/importSettings/index.ts
@@ -3,5 +3,6 @@ export const importSettings = {
     node: {
       extensions: [".js", ".jsx", ".json", ".ts", ".tsx"],
     },
+    typescript: {},
   },
 } as const

--- a/yarn.lock
+++ b/yarn.lock
@@ -4102,6 +4102,7 @@ __metadata:
     eslint-config-airbnb: "npm:^19.0.4"
     eslint-config-sc-js: "npm:^0.0.7"
     fixpack: "npm:^4.0.0"
+    globals: "npm:^15.6.0"
     npm-run-all2: "npm:^6.2.0"
     prettier: "npm:^3.3.2"
     react: "npm:^18.3.1"
@@ -5064,6 +5065,13 @@ __metadata:
   version: 14.0.0
   resolution: "globals@npm:14.0.0"
   checksum: 10c0/b96ff42620c9231ad468d4c58ff42afee7777ee1c963013ff8aabe095a451d0ceeb8dcd8ef4cbd64d2538cef45f787a78ba3a9574f4a634438963e334471302d
+  languageName: node
+  linkType: hard
+
+"globals@npm:^15.6.0":
+  version: 15.6.0
+  resolution: "globals@npm:15.6.0"
+  checksum: 10c0/ba488ec5bd770336a3e1ffec3f718077768aec99e16f30c33c0eeaed09e0b93fa06a24fc0d3844d1d81a678c86d22f04547703e87e2e4353601eddcb800479ec
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3743,6 +3743,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"enhanced-resolve@npm:^5.12.0":
+  version: 5.17.0
+  resolution: "enhanced-resolve@npm:5.17.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.4"
+    tapable: "npm:^2.2.0"
+  checksum: 10c0/90065e58e4fd08e77ba47f827eaa17d60c335e01e4859f6e644bb3b8d0e32b203d33894aee92adfa5121fa262f912b48bdf0d0475e98b4a0a1132eea1169ad37
+  languageName: node
+  linkType: hard
+
 "env-paths@npm:^2.2.0, env-paths@npm:^2.2.1":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
@@ -4136,6 +4146,7 @@ __metadata:
     editorconfig-checker: "npm:^5.1.8"
     eslint: "npm:^8.57.0"
     eslint-config-sc-js: "npm:^0.0.7"
+    eslint-import-resolver-typescript: "npm:^3.6.1"
     fixpack: "npm:^4.0.0"
     npm-run-all2: "npm:^6.2.0"
     prettier: "npm:^3.3.2"
@@ -4156,7 +4167,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.8.0":
+"eslint-import-resolver-typescript@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "eslint-import-resolver-typescript@npm:3.6.1"
+  dependencies:
+    debug: "npm:^4.3.4"
+    enhanced-resolve: "npm:^5.12.0"
+    eslint-module-utils: "npm:^2.7.4"
+    fast-glob: "npm:^3.3.1"
+    get-tsconfig: "npm:^4.5.0"
+    is-core-module: "npm:^2.11.0"
+    is-glob: "npm:^4.0.3"
+  peerDependencies:
+    eslint: "*"
+    eslint-plugin-import: "*"
+  checksum: 10c0/cb1cb4389916fe78bf8c8567aae2f69243dbfe624bfe21078c56ad46fa1ebf0634fa7239dd3b2055ab5c27359e4b4c28b69b11fcb3a5df8a9e6f7add8e034d86
+  languageName: node
+  linkType: hard
+
+"eslint-module-utils@npm:^2.7.4, eslint-module-utils@npm:^2.8.0":
   version: 2.8.1
   resolution: "eslint-module-utils@npm:2.8.1"
   dependencies:
@@ -4597,7 +4626,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2":
+"fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.1, fast-glob@npm:^3.3.2":
   version: 3.3.2
   resolution: "fast-glob@npm:3.3.2"
   dependencies:
@@ -4922,6 +4951,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-tsconfig@npm:^4.5.0":
+  version: 4.7.5
+  resolution: "get-tsconfig@npm:4.7.5"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10c0/a917dff2ba9ee187c41945736bf9bbab65de31ce5bc1effd76267be483a7340915cff232199406379f26517d2d0a4edcdbcda8cca599c2480a0f2cf1e1de3efa
+  languageName: node
+  linkType: hard
+
 "git-raw-commits@npm:^4.0.0":
   version: 4.0.0
   resolution: "git-raw-commits@npm:4.0.0"
@@ -5062,7 +5100,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -5397,6 +5435,15 @@ __metadata:
   version: 1.2.7
   resolution: "is-callable@npm:1.2.7"
   checksum: 10c0/ceebaeb9d92e8adee604076971dd6000d38d6afc40bb843ea8e45c5579b57671c3f3b50d7f04869618242c6cee08d1b67806a8cb8edaaaf7c0748b3720d6066f
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.11.0":
+  version: 2.14.0
+  resolution: "is-core-module@npm:2.14.0"
+  dependencies:
+    hasown: "npm:^2.0.2"
+  checksum: 10c0/ae8dbc82bd20426558bc8d20ce290ce301c1cfd6ae4446266d10cacff4c63c67ab16440ade1d72ced9ec41c569fbacbcee01e293782ce568527c4cdf35936e4c
   languageName: node
   linkType: hard
 
@@ -7568,6 +7615,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 10c0/fb8f7bbe2ca281a73b7ef423a1cbc786fb244bd7a95cbe5c3fba25b27d327150beca8ba02f622baea65919a57e061eb5005204daa5f93ed590d9b77463a567ab
+  languageName: node
+  linkType: hard
+
 "resolve.exports@npm:^2.0.0":
   version: 2.0.2
   resolution: "resolve.exports@npm:2.0.2"
@@ -8229,6 +8283,13 @@ __metadata:
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
   checksum: 10c0/6c4032340701a9950865f7ae8ef38578d8d7053f5e10518076e6554a9381fa91bd9c6850193695c141f32b21f979c985db07265a758867bac95de05f7d8aeb39
+  languageName: node
+  linkType: hard
+
+"tapable@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "tapable@npm:2.2.1"
+  checksum: 10c0/bc40e6efe1e554d075469cedaba69a30eeb373552aaf41caeaaa45bf56ffacc2674261b106245bd566b35d8f3329b52d838e851ee0a852120acae26e622925c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## eslint-config-jest
- turn off `import/no-extraneous-dependencies`

## eslint-config-js
- turn off `quote-props`, because enabled at `@stylistic`
- turn off `arrow-parens`, because enabled at `@stylistic`
- change `@stylistic/arrow-parens` to `always` as error

## eslint-config-react
- swtich enable order the eslint-plugin-react/jsx-runtime, eslint-plugin-react/recommended
- turn off `react/jsx-one-expression-per-line`, because enabled at `@stylistic`
- apply `globals` for browser global

## eslint-config-storybook
- turn off `import/no-extraneous-dependencies`
- change `max-statements` to 30

## eslint-config-ts
- apply `eslint-import-resolver-typescript`
- turn off `dot-notation`, because requires this at typescript
- turn off `no-unused-expressions`, because enabled at `@typescript-eslint`