### PR TITLE
Support eslint v9, typescript-eslint v8

### DIFF
--- a/dry-run/dr-eslint-plugin-sc-js/package.json
+++ b/dry-run/dr-eslint-plugin-sc-js/package.json
@@ -17,7 +17,7 @@
     "prepare:dependence-build": "yarn workspaces foreach -R -ipt run build"
   },
   "devDependencies": {
-    "eslint": "^8.57.0",
+    "eslint": "^9.9.0",
     "eslint-plugin-sc-js": "workspace:^",
     "fixpack": "^4.0.0",
     "npm-run-all2": "^6.2.2",

--- a/packages/eslint-plugin-js/README.md
+++ b/packages/eslint-plugin-js/README.md
@@ -2,6 +2,8 @@
 - Strict Check rules for eslint.
 - - For Javascript / Typescript.
 
+**Supports eslint v9.**
+
 ## Installation
 
 ```shell

--- a/packages/eslint-plugin-js/docs/rules/file-path-patterns.md
+++ b/packages/eslint-plugin-js/docs/rules/file-path-patterns.md
@@ -6,41 +6,52 @@
 ```js
 ...
 "sc-js/file-path-patterns": [<enabled>, {
-  "allowPatterns": <RegExp>[]
+  "allowPatterns": <RegExp>[], // Deprecated
+  "allowPatterns": <RegExp like string>[], // Next standard. string that be able to hands over to RegExp
 }]
 ...
 ```
 
 ### `allowPatterns`
 - Specify the regular expression array for allows path
+- Deprecated: array of regular expression
+- Next standard: array of string that be able to hands overt to RegExp
 
 #### value: `[/index(?:\.(?:stories|test))?\.tsx?/]`
 
-Example of **invalid** :x: code when option value `[/index(?:\.(?:stories|test))?\.tsx?/]`:
+Example of **invalid** :x: code when option values
+- `[/index(?:\.(?:stories|test))?\.tsx?/]`:
+- `["index(?:.(?:stories|test))?.tsx?/"]`:
 
 
 ```tsx
 // "sc-js/file-path-patterns": ["error", { "allowPatterns": [/index(?:\.(?:stories|test))?\.tsx?/] }]
+// "sc-js/file-path-patterns": ["error", { "allowPatterns": ["index(?:.(?:stories|test))?.tsx?"] }]
 // Button.tsx
 import { useState } from "react"
 ```
 
-Example of **valid** :o: code when option value `[/index(?:\.(?:stories|test))?\.tsx?/]`:
+Example of **valid** :o: code when option values
+- `[/index(?:\.(?:stories|test))?\.tsx?/]`:
+- `["index(?:.(?:stories|test))?.tsx?"]`:
 
 ```tsx
 // "sc-js/file-path-patterns": ["error", { "allowPatterns": [/index(?:\.(?:stories|test))?\.tsx?/] }]
+// "sc-js/file-path-patterns": ["error", { "allowPatterns": ["index(?:.(?:stories|test))?.tsx?"] }]
 // Button/index.tsx
 import { useState } from "react"
 ```
 
 ```tsx
 // "sc-js/file-path-patterns": ["error", { "allowPatterns": [/index(?:\.(?:stories|test))?\.tsx?/] }]
+// "sc-js/file-path-patterns": ["error", { "allowPatterns": ["index(?:.(?:stories|test))?.tsx?"] }]
 // Button/index.stories.tsx
 import { Button } from "./"
 ```
 
 ```tsx
 // "sc-js/file-path-patterns": ["error", { "allowPatterns": [/index(?:\.(?:stories|test))?\.tsx?/] }]
+// "sc-js/file-path-patterns": ["error", { "allowPatterns": ["index(?:.(?:stories|test))?.tsx?"] }]
 // Button/index.test.tsx
 import { Button } from "./"
 ```

--- a/packages/eslint-plugin-js/docs/rules/match-names-of-file-and-export.md
+++ b/packages/eslint-plugin-js/docs/rules/match-names-of-file-and-export.md
@@ -7,28 +7,37 @@
 ```js
 ...
 "sc-js/match-names-of-file-and-export": [<enabled>, {
-  "captures": <RegExp>[]
+  "captures": <RegExp>[], // Deprecated
+  "captures": <RegExp>[], // Next standard. string that be able to hands over to RegExp
 }]
 ...
 ```
 
 ### `captures`
 - Specify the regular expression array for allows path
+- Deprecated: array of regular expression
+- Next standard: array of string that be able to hands overt to RegExp
 
-#### value: `[/\/components\/(?:atoms|molecules|organsims|templates)\/([^/]+)\/index.tsx/]`
+#### value: `[/\/components\/(?:atoms|molecules|organsims|templates)\/([^/]+)\/index\.tsx/]`
 
-Example of **invalid** :x: code when option value `[/\/components\/(?:atoms|molecules|organsims|templates)\/([^/]+)\/index.tsx/]`:
+Example of **invalid** :x: code when option values
+- `[/\/components\/(?:atoms|molecules|organsims|templates)\/([^/]+)\/index\.tsx/]`:
+- `["components(?:atoms|molecules|organsims|templates)([^/]+)index.tsx"]`:
 
 ```tsx
-// "sc-js/match-names-of-file-and-export": ["error", { "captures": [/\/components\/(?:atoms|molecules|organsims|templates)\/([^/]+)\/index.tsx/] }]
+// "sc-js/match-names-of-file-and-export": ["error", { "captures": [/\/components\/(?:atoms|molecules|organsims|templates)\/([^/]+)\/index\.tsx/] }]
+// "sc-js/match-names-of-file-and-export": ["error", { "captures": ["/components/(?:atoms|molecules|organsims|templates)/([^/]+)/index.tsx"] }]
 // /components/atoms/Button/index.tsx
 export const button = () => {}
 ```
 
-Example of **valid** :o: code when option value `[/\/components\/(?:atoms|molecules|organsims|templates)\/([^/]+)\/index.tsx/]`:
+Example of **valid** :o: code when option values
+- `[/\/components\/(?:atoms|molecules|organsims|templates)\/([^/]+)\/index\.tsx/]`:
+- `["/components/(?:atoms|molecules|organsims|templates)/([^/]+)/index.tsx"]`:
 
 ```tsx
 // "sc-js/match-names-of-file-and-export": ["error", { "captures": [/\/components\/(?:atoms|molecules|organsims|templates)\/([^/]+)\/index.tsx/]] }]
+// "sc-js/match-names-of-file-and-export": ["error", { "captures": ["/components/(?:atoms|molecules|organsims|templates)/([^/]+)/index.tsx"]] }]
 // /components/atoms/Button/index.tsx
 export const Button = () => {}
 ```

--- a/packages/eslint-plugin-js/eslint.config.mjs
+++ b/packages/eslint-plugin-js/eslint.config.mjs
@@ -1,29 +1,39 @@
-import { BASE_RECORDS } from "strict-check/config/eslint/records/BASE_RECORDS/index.mjs"
-import { CONFIGS_RECORD } from "strict-check/config/eslint/records/CONFIGS_RECORD/index.mjs"
-import { ESLINT_CONFIG_RECORD } from "strict-check/config/eslint/records/ESLINT_CONFIG_RECORD/index.mjs"
+// TODO: 使用してる config, plugin が v9 に対応したら custom config に戻す
+import eslint from "@eslint/js"
+// import { BASE_RECORDS } from "strict-check/config/eslint/records/BASE_RECORDS/index.mjs"
+// import { CONFIGS_RECORD } from "strict-check/config/eslint/records/CONFIGS_RECORD/index.mjs"
+// import { ESLINT_CONFIG_RECORD } from "strict-check/config/eslint/records/ESLINT_CONFIG_RECORD/index.mjs"
 import { IGNORE_RECORD } from "strict-check/config/eslint/records/IGNORE_RECORD/index.mjs"
-import { SCRIPTS_RECORD } from "strict-check/config/eslint/records/SCRIPTS_RECORD/index.mjs"
-import { TEST_RECORD } from "strict-check/config/eslint/records/TEST_RECORD/index.mjs"
-import { TYPESCRIPT_RECORDS } from "strict-check/config/eslint/records/TYPESCRIPT_RECORDS/index.mjs"
+// import { SCRIPTS_RECORD } from "strict-check/config/eslint/records/SCRIPTS_RECORD/index.mjs"
+// import { TEST_RECORD } from "strict-check/config/eslint/records/TEST_RECORD/index.mjs"
+// import { TYPESCRIPT_RECORDS } from "strict-check/config/eslint/records/TYPESCRIPT_RECORDS/index.mjs"
 
 const CONFIG = [
+  // TODO: 使用してる config, plugin が v9 に対応したら custom config に戻す
+  eslint.configs.recommended,
   IGNORE_RECORD,
   {
     ignores: ["src/libs/**"],
   },
-  ...BASE_RECORDS,
-  ...TYPESCRIPT_RECORDS,
-  SCRIPTS_RECORD,
-  CONFIGS_RECORD,
-  ESLINT_CONFIG_RECORD,
-  TEST_RECORD,
+  // ...BASE_RECORDS,
+  // ...TYPESCRIPT_RECORDS,
+  // SCRIPTS_RECORD,
+  // CONFIGS_RECORD,
+  // ESLINT_CONFIG_RECORD,
+  // TEST_RECORD,
+  // {
+  //   settings: {
+  //     "import/resolver": {
+  //       node: {
+  //         extensions: [".ts"],
+  //       },
+  //     },
+  //   },
+  // },
   {
-    settings: {
-      "import/resolver": {
-        node: {
-          extensions: [".ts"],
-        },
-      },
+    files: ["cspell.config.js", "jest.config.js"],
+    rules: {
+      "no-undef": 0,
     },
   },
 ]

--- a/packages/eslint-plugin-js/package.json
+++ b/packages/eslint-plugin-js/package.json
@@ -57,8 +57,8 @@
     "@swc/jest": "^0.2.36",
     "@tsconfig/strictest": "^2.0.5",
     "@types/jest": "^29.5.12",
-    "@typescript-eslint/rule-tester": "^7.17.0",
-    "@typescript-eslint/utils": "^7.17.0",
+    "@typescript-eslint/rule-tester": "^8.1.0",
+    "@typescript-eslint/utils": "^8.1.0",
     "chokidar-cli": "^3.0.0",
     "cspell": "^8.12.1",
     "editorconfig-checker": "^5.1.8",
@@ -71,7 +71,7 @@
     "prettier": "^3.3.3",
     "strict-check": "workspace:^",
     "typescript": "^5.5.4",
-    "typescript-eslint": "^7.17.0"
+    "typescript-eslint": "^8.1.0"
   },
   "packageManager": "yarn@4.2.2"
 }

--- a/packages/eslint-plugin-js/package.json
+++ b/packages/eslint-plugin-js/package.json
@@ -73,5 +73,8 @@
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.1.0"
   },
+  "peerDependencies": {
+    "eslint": "^8.57.0 || ^9.9.0"
+  },
   "packageManager": "yarn@4.2.2"
 }

--- a/packages/eslint-plugin-js/package.json
+++ b/packages/eslint-plugin-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-sc-js",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Strict Check rules for eslint for javascript / typescript",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-js/spec/tests/rules/file-path-patterns/index.test.ts
+++ b/packages/eslint-plugin-js/spec/tests/rules/file-path-patterns/index.test.ts
@@ -6,106 +6,22 @@ import type {
   Option,
 } from "../../../../src/rules/file-path-patterns/types"
 
-const RegularExpressions = {
-  ATOMIC_DESIGN:
-    /\/components\/atoms\/[A-Z][^.]+\/index(?:\.(?:stories|test))?\.tsx?/,
-  TYPES: /\/@types\/[^/]+\/[^.]+\.d\.ts/,
-} satisfies Record<Uppercase<string>, RegExp>
-
-const options = [
-  {
-    allowPatterns: [RegularExpressions.ATOMIC_DESIGN, RegularExpressions.TYPES],
-  },
-]
-
 tester.run<MessageId, Option[]>("file-path-patterns", filePathPatterns, {
   valid: [
     {
-      code: "console.log(\"valid pattern1\")",
-      filename: "/components/atoms/Button/index.tsx",
-      options,
-    },
-    {
-      code: "console.log(\"valid pattern2\")",
-      filename: "/components/atoms/Button/index.ts",
-      options,
-    },
-    {
-      code: "console.log(\"valid pattern3\")",
-      filename: "/components/atoms/Button/index.tsx",
-      options,
-    },
-    {
-      code: "console.log(\"valid pattern4\")",
-      filename: "/components/atoms/Button/index.stories.tsx",
-      options,
-    },
-    {
-      code: "console.log(\"valid pattern5\")",
-      filename: "/components/atoms/Button/index.test.ts",
-      options,
-    },
-    {
-      code: "console.log(\"valid pattern6\")",
-      filename: "/components/atoms/Button/index.test.tsx",
-      options,
-    },
-    {
-      code: "console.log(\"valid pattern7\")",
-      filename: "/@types/type/button.d.ts",
-      options,
+      code: "console.log(\"valid pattern\")",
+      options: [{
+        allowPatterns: [".+/index.tsx", /.+\/index\.tsx/],
+      }],
     },
   ],
 
   invalid: [
     {
-      code: "console.log(\"invalid pattern3\")",
-      filename: "relatedComponents/atoms/button/index.tsx",
-      options,
-
-      errors: [
-        {
-          messageId: "NotMatched",
-        },
-      ],
-    },
-    {
-      code: "console.log(\"invalid pattern4\")",
-      filename: "/components/atoms/button/index.tsx",
-      options,
-
-      errors: [
-        {
-          messageId: "NotMatched",
-        },
-      ],
-    },
-    {
-      code: "console.log(\"invalid pattern5\")",
-      filename: "/components/Button/index.tsx",
-      options,
-
-      errors: [
-        {
-          messageId: "NotMatched",
-        },
-      ],
-    },
-    {
-      code: "console.log(\"invalid pattern6\")",
-      filename: "/components/Button.tsx",
-      options,
-
-      errors: [
-        {
-          messageId: "NotMatched",
-        },
-      ],
-    },
-    {
-      code: "console.log(\"invalid pattern7\")",
-      filename: "/components/types/Button.ts",
-      options,
+      code: "console.log(\"invalid pattern\")",
+      options: [{
+        allowPatterns: ["button.tsx", /button\.tsx/],
+      }],
 
       errors: [
         {

--- a/packages/eslint-plugin-js/spec/tests/rules/match-names-of-file-and-export/index.test.ts
+++ b/packages/eslint-plugin-js/spec/tests/rules/match-names-of-file-and-export/index.test.ts
@@ -6,20 +6,11 @@ import type {
   Option,
 } from "../../../../src/rules/match-names-of-file-and-export/types"
 
-const correctOptions: Option[] = [
+const options: Option[] = [
   {
     captures: [
-      /\/components\/(?:atoms|molecules|organisms|templates)\/([^/]+)\/index.tsx/,
-      /\/modules\/([^/]+)\/index.ts/,
-    ],
-  },
-]
-
-const incorrectOptions: Option[] = [
-  {
-    captures: [
-      /\/components\/atoms\/[^/]+\/index.tsx/,
-      /\/modules\/[^/]+\/index.ts/,
+      "/(.+)/index.tsx",
+      /(.+)\/index.tsx/,
     ],
   },
 ]
@@ -31,60 +22,20 @@ tester.run<MessageId, Option[]>(
     valid: [
       {
         code: "export const Button: FC<> = () => {};",
-        filename: "/components/atoms/Button/index.tsx",
-        options: correctOptions,
-      },
-      {
-        code: "export const useButton = () => {}",
-        filename: "/components/atoms/Button/modules/useButton/index.ts",
-        options: correctOptions,
+        options,
       },
     ],
 
     invalid: [
       {
         code: "export const button = () => {}",
-        filename: "/components/atoms/Button/index.tsx",
-        options: correctOptions,
+        options,
 
         errors: [
           {
             data: {
               capturedString: "Button",
-              filepath: "/components/atoms/Button/index.tsx",
               variableName: "button",
-            },
-            messageId: "FileAndExportAreDifferent",
-          },
-        ],
-      },
-      {
-        code: "export const useButtonHooks = () => {}",
-        filename: "/components/atoms/Button/modules/useButton/index.ts",
-        options: incorrectOptions,
-
-        errors: [
-          {
-            data: {
-              capturedString: "undefined",
-              filepath: "/components/atoms/Button/modules/useButton/index.ts",
-              variableName: "useButtonHooks",
-            },
-            messageId: "FileAndExportAreDifferent",
-          },
-        ],
-      },
-      {
-        code: "export const useButtonHooks = () => {}",
-        filename: "/components/atoms/Button/modules/useButton/index.ts",
-        options: correctOptions,
-
-        errors: [
-          {
-            data: {
-              capturedString: "useButton",
-              filepath: "/components/atoms/Button/modules/useButton/index.ts",
-              variableName: "useButtonHooks",
             },
             messageId: "FileAndExportAreDifferent",
           },

--- a/packages/eslint-plugin-js/spec/tests/rules/utils/tester/index.ts
+++ b/packages/eslint-plugin-js/spec/tests/rules/utils/tester/index.ts
@@ -2,10 +2,15 @@
 import { RuleTester } from "@typescript-eslint/rule-tester"
 
 export const tester = new RuleTester({
-  parser: require.resolve("@typescript-eslint/parser"),
-  parserOptions: {
-    ecmaFeatures: {
-      jsx: true,
+  defaultFilenames: {
+    ts: "sample/useButton/index.ts",
+    tsx: "sample/Button/index.tsx",
+  },
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
     },
   },
 })

--- a/packages/eslint-plugin-js/src/rules/file-path-patterns/modules/program/index.ts
+++ b/packages/eslint-plugin-js/src/rules/file-path-patterns/modules/program/index.ts
@@ -21,7 +21,7 @@ export const program: Program = (context) => {
   }
 
   const isPartialMatched = allowPatterns.some((pattern) =>
-    pattern.test(filename))
+    new RegExp(pattern).test(filename))
 
   return (node) => {
     if (isPartialMatched) return

--- a/packages/eslint-plugin-js/src/rules/file-path-patterns/schema/optionSchema/index.ts
+++ b/packages/eslint-plugin-js/src/rules/file-path-patterns/schema/optionSchema/index.ts
@@ -5,7 +5,8 @@ import { ARRAY_LENGTHS } from "../../../../libs/shared-for-plugin"
 export const optionsSchema = z
   .array(
     z.object({
-      allowPatterns: z.array(z.instanceof(RegExp)),
+      // TODO: 正規表現を削除するタイミングで z.string にする
+      allowPatterns: z.array(z.any()),
     }),
   )
   .length(ARRAY_LENGTHS.ONE)

--- a/packages/eslint-plugin-js/src/rules/match-names-of-file-and-export/modules/exportNamedDeclaration/index.ts
+++ b/packages/eslint-plugin-js/src/rules/match-names-of-file-and-export/modules/exportNamedDeclaration/index.ts
@@ -23,7 +23,7 @@ export const exportNamedDeclaration: ExportNamedDeclaration = (context) => {
     throw new Error("")
   }
 
-  const matchedCapture = captures.find((capture) => capture.test(filename))
+  const matchedCapture = captures.find((capture) => new RegExp(capture).test(filename))
 
   return (node) => {
     if (!matchedCapture) return

--- a/packages/eslint-plugin-js/src/rules/match-names-of-file-and-export/schema/optionSchema/index.ts
+++ b/packages/eslint-plugin-js/src/rules/match-names-of-file-and-export/schema/optionSchema/index.ts
@@ -5,7 +5,8 @@ import { ARRAY_LENGTHS } from "../../../../libs/shared-for-plugin"
 export const optionsSchema = z
   .array(
     z.object({
-      captures: z.array(z.instanceof(RegExp)),
+      // TODO: 正規表現を削除するタイミングで z.string にする
+      captures: z.array(z.any()),
     }),
   )
   .length(ARRAY_LENGTHS.ONE)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2042,6 +2042,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/eslint-plugin@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.1.0"
+  dependencies:
+    "@eslint-community/regexpp": "npm:^4.10.0"
+    "@typescript-eslint/scope-manager": "npm:8.1.0"
+    "@typescript-eslint/type-utils": "npm:8.1.0"
+    "@typescript-eslint/utils": "npm:8.1.0"
+    "@typescript-eslint/visitor-keys": "npm:8.1.0"
+    graphemer: "npm:^1.4.0"
+    ignore: "npm:^5.3.1"
+    natural-compare: "npm:^1.4.0"
+    ts-api-utils: "npm:^1.3.0"
+  peerDependencies:
+    "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
+    eslint: ^8.57.0 || ^9.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/7bbeae588f859b59c34d6a76cac06ef0fa605921b40c5d3b65b94829984280ea84c4dd3f5cb9ce2eb326f5563e9abb4c90ebff05c47f83f4def296c2ea1fa86c
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/parser@npm:7.17.0, @typescript-eslint/parser@npm:^7.17.0":
   version: 7.17.0
   resolution: "@typescript-eslint/parser@npm:7.17.0"
@@ -2060,20 +2083,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/rule-tester@npm:^7.17.0":
-  version: 7.17.0
-  resolution: "@typescript-eslint/rule-tester@npm:7.17.0"
+"@typescript-eslint/parser@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/parser@npm:8.1.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:7.17.0"
-    "@typescript-eslint/utils": "npm:7.17.0"
+    "@typescript-eslint/scope-manager": "npm:8.1.0"
+    "@typescript-eslint/types": "npm:8.1.0"
+    "@typescript-eslint/typescript-estree": "npm:8.1.0"
+    "@typescript-eslint/visitor-keys": "npm:8.1.0"
+    debug: "npm:^4.3.4"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/b94b2d3ab5ca505484d100701fad6a04a5dc8d595029bac1b9f5b8a4a91d80fd605b0f65d230b36a97ab7e5d55eeb0c28af2ab63929a3e4ab8fdefd2a548c36b
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/rule-tester@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/rule-tester@npm:8.1.0"
+  dependencies:
+    "@typescript-eslint/typescript-estree": "npm:8.1.0"
+    "@typescript-eslint/utils": "npm:8.1.0"
     ajv: "npm:^6.12.6"
     json-stable-stringify-without-jsonify: "npm:^1.0.1"
     lodash.merge: "npm:4.6.2"
     semver: "npm:^7.6.0"
   peerDependencies:
     "@eslint/eslintrc": ">=2"
-    eslint: ^8.56.0
-  checksum: 10c0/c6d4458ff911dc374ccb2c78ed7ecaa10201256f1201602bbd7a1c61533646508cb40b2b9a8ff97936c2e04b9348bd01321a595d7f7bd17508dce8831cd332d3
+    eslint: ^8.57.0 || ^9.0.0
+  checksum: 10c0/b119afe19f41734222d9eb902480eadf8b61bbe1da0068b317c9ba1fe3efd903a1096902f6e1e8b1a456d6da855de714628474ffcaa29ad0bf420d96ddb4f59e
   languageName: node
   linkType: hard
 
@@ -2107,6 +2148,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.1.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.1.0"
+    "@typescript-eslint/visitor-keys": "npm:8.1.0"
+  checksum: 10c0/2bcf8cd176a1819bddcae16c572e7da8fba821b995a91cd53d64d8d6b85a17f5a895522f281ba57e34929574bddd4d6684ee3e545ec4e8096be4c3198e253a9a
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:7.17.0":
   version: 7.17.0
   resolution: "@typescript-eslint/type-utils@npm:7.17.0"
@@ -2121,6 +2172,21 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/b415cf37c0922cded78735c5049cb5a5b0065e1c0ce4a81ca2a26422763ccacca8945efa45480f40530f2ec414a14d35a88a6798258aa889f7a9cf4ca4a240cd
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/type-utils@npm:8.1.0"
+  dependencies:
+    "@typescript-eslint/typescript-estree": "npm:8.1.0"
+    "@typescript-eslint/utils": "npm:8.1.0"
+    debug: "npm:^4.3.4"
+    ts-api-utils: "npm:^1.3.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/62753941c4136e8d2daa72fe0410dea48e5317a6f12ece6382ca85e29912bd1b3f739b61d1060fc0a1f8c488dfc905beab4c8b8497951a21c3138a659c7271ec
   languageName: node
   linkType: hard
 
@@ -2142,6 +2208,13 @@ __metadata:
   version: 7.17.0
   resolution: "@typescript-eslint/types@npm:7.17.0"
   checksum: 10c0/8f734294d432b37c534f17eb2befdfe43b76874d09118d6adf7e308e5a586e9e11b7021abe4f6692a6e6226de58a15b3cfe1300939556ce1c908d9af627b7400
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/types@npm:8.1.0"
+  checksum: 10c0/ceade44455f45974e68956016c4d1c6626580732f7f9675e14ffa63db80b551752b0df596b20473dae9f0dc6ed966e17417dc2cf36e1a82b6ab0edc97c5eaa50
   languageName: node
   linkType: hard
 
@@ -2201,6 +2274,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.1.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.1.0"
+    "@typescript-eslint/visitor-keys": "npm:8.1.0"
+    debug: "npm:^4.3.4"
+    globby: "npm:^11.1.0"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^1.3.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/a7bc8275df1c79c4cb14ef086c56674316dd4907efec53eddca35d0b5220428b69c82178ce2d95138da2e398269c8bd0764cae8020a36417e411e35c3c47bc4b
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:7.17.0, @typescript-eslint/utils@npm:^7.17.0":
   version: 7.17.0
   resolution: "@typescript-eslint/utils@npm:7.17.0"
@@ -2212,6 +2304,20 @@ __metadata:
   peerDependencies:
     eslint: ^8.56.0
   checksum: 10c0/1f3e22820b3ab3e47809c45e576614ad4a965f5c8634856eca5c70981386b9351a77fb172ba32345e7c5667479cf9526c673699dd38dccd0616ad6db21704e72
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:8.1.0, @typescript-eslint/utils@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/utils@npm:8.1.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@typescript-eslint/scope-manager": "npm:8.1.0"
+    "@typescript-eslint/types": "npm:8.1.0"
+    "@typescript-eslint/typescript-estree": "npm:8.1.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+  checksum: 10c0/c95503a6bdcd98b1ff04d1adbf46377b2036b1c510d90a4a056401f996f775f06c3108c95fb81cd6babc9c97b73b91b8e848f0337bc508de8a49c993582f0e75
   languageName: node
   linkType: hard
 
@@ -2274,6 +2380,16 @@ __metadata:
     "@typescript-eslint/types": "npm:7.17.0"
     eslint-visitor-keys: "npm:^3.4.3"
   checksum: 10c0/fa6b339d51fc3710288bb2ffaa46d639551d77965cc42c36f96c4f43aed663ff12972e8a28652a280f6ce20b7a92dc2aea14b2b4049012799be2fc2d3cbb2c60
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.1.0":
+  version: 8.1.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.1.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.1.0"
+    eslint-visitor-keys: "npm:^3.4.3"
+  checksum: 10c0/b7544dbb0eec1ddbfcd95c04b51b9a739c2e768c16d1c88508f976a2b0d1bc02fefb7491930e06e48073a5c07c6f488cd8403bba3a8b918888b93a88d5ac3869
   languageName: node
   linkType: hard
 
@@ -4327,8 +4443,8 @@ __metadata:
     "@swc/jest": "npm:^0.2.36"
     "@tsconfig/strictest": "npm:^2.0.5"
     "@types/jest": "npm:^29.5.12"
-    "@typescript-eslint/rule-tester": "npm:^7.17.0"
-    "@typescript-eslint/utils": "npm:^7.17.0"
+    "@typescript-eslint/rule-tester": "npm:^8.1.0"
+    "@typescript-eslint/utils": "npm:^8.1.0"
     chokidar-cli: "npm:^3.0.0"
     cspell: "npm:^8.12.1"
     editorconfig-checker: "npm:^5.1.8"
@@ -4341,7 +4457,7 @@ __metadata:
     prettier: "npm:^3.3.3"
     strict-check: "workspace:^"
     typescript: "npm:^5.5.4"
-    typescript-eslint: "npm:^7.17.0"
+    typescript-eslint: "npm:^8.1.0"
     zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
@@ -8570,6 +8686,20 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/5d9a5430b139129474cd65655ef05efeddfbd890a3ff28c1dd3b747cf48c938cf18e95b3cbbb4a7f8bf991c6c2de5e82f685768c2e7d691629a404a178672a13
+  languageName: node
+  linkType: hard
+
+"typescript-eslint@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "typescript-eslint@npm:8.1.0"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": "npm:8.1.0"
+    "@typescript-eslint/parser": "npm:8.1.0"
+    "@typescript-eslint/utils": "npm:8.1.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/9b5769b95aeca54ae9fa15cd2f0e5656747f643a7be220513555de143ff19d70c5945eb82259a3fb29ab4d37f4d158f7f088e7b2cf98e2e8253a7429ac19d072
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4459,6 +4459,8 @@ __metadata:
     typescript: "npm:^5.5.4"
     typescript-eslint: "npm:^8.1.0"
     zod: "npm:^3.23.8"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.9.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,6 +1117,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint-community/regexpp@npm:^4.11.0":
+  version: 4.11.0
+  resolution: "@eslint-community/regexpp@npm:4.11.0"
+  checksum: 10c0/0f6328869b2741e2794da4ad80beac55cba7de2d3b44f796a60955b0586212ec75e6b0253291fd4aad2100ad471d1480d8895f2b54f1605439ba4c875e05e523
+  languageName: node
+  linkType: hard
+
+"@eslint/config-array@npm:^0.17.1":
+  version: 0.17.1
+  resolution: "@eslint/config-array@npm:0.17.1"
+  dependencies:
+    "@eslint/object-schema": "npm:^2.1.4"
+    debug: "npm:^4.3.1"
+    minimatch: "npm:^3.1.2"
+  checksum: 10c0/b986a0a96f2b42467578968ce3d4ae3b9284e587f8490f2dcdc44ff1b8d30580c62b221da6e58d07b09e156c3050e2dc38267f9370521d9cafc099c4e30154ef
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^2.1.4":
   version: 2.1.4
   resolution: "@eslint/eslintrc@npm:2.1.4"
@@ -1158,6 +1176,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/js@npm:9.9.0":
+  version: 9.9.0
+  resolution: "@eslint/js@npm:9.9.0"
+  checksum: 10c0/6ec9f1f0d576132444d6a5c66a8a08b0be9444e3ebb563fa6a6bebcf5299df3da7e454dc04c0fa601bb811197f00764b3a04430d8458cdb8e3a4677993d23f30
+  languageName: node
+  linkType: hard
+
 "@eslint/js@npm:^9.5.0":
   version: 9.5.0
   resolution: "@eslint/js@npm:9.5.0"
@@ -1169,6 +1194,13 @@ __metadata:
   version: 9.7.0
   resolution: "@eslint/js@npm:9.7.0"
   checksum: 10c0/73fc10666f6f4aed6f58e407e09f42ceb0d42fa60c52701c64ea9f59a81a6a8ad5caecdfd423d03088481515fe7ec17eb461acb4ef1ad70b649b6eae465b3164
+  languageName: node
+  linkType: hard
+
+"@eslint/object-schema@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@eslint/object-schema@npm:2.1.4"
+  checksum: 10c0/e9885532ea70e483fb007bf1275968b05bb15ebaa506d98560c41a41220d33d342e19023d5f2939fed6eb59676c1bda5c847c284b4b55fce521d282004da4dda
   languageName: node
   linkType: hard
 
@@ -1194,6 +1226,13 @@ __metadata:
   version: 2.0.3
   resolution: "@humanwhocodes/object-schema@npm:2.0.3"
   checksum: 10c0/80520eabbfc2d32fe195a93557cef50dfe8c8905de447f022675aaf66abc33ae54098f5ea78548d925aa671cd4ab7c7daa5ad704fe42358c9b5e7db60f80696c
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/retry@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@humanwhocodes/retry@npm:0.3.0"
+  checksum: 10c0/7111ec4e098b1a428459b4e3be5a5d2a13b02905f805a2468f4fa628d072f0de2da26a27d04f65ea2846f73ba51f4204661709f05bfccff645e3cedef8781bb6
   languageName: node
   linkType: hard
 
@@ -2434,6 +2473,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 10c0/a19f9dead009d3b430fa3c253710b47778cdaace15b316de6de93a68c355507bc1072a9956372b6c990cbeeb167d4a929249d0faeb8ae4bb6911d68d53299549
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.12.0":
+  version: 8.12.1
+  resolution: "acorn@npm:8.12.1"
+  bin:
+    acorn: bin/acorn
+  checksum: 10c0/51fb26cd678f914e13287e886da2d7021f8c2bc0ccc95e03d3e0447ee278dd3b40b9c57dc222acd5881adcf26f3edc40901a4953403232129e3876793cd17386
   languageName: node
   linkType: hard
 
@@ -3788,7 +3836,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "dr-eslint-plugin-sc-js@workspace:dry-run/dr-eslint-plugin-sc-js"
   dependencies:
-    eslint: "npm:^8.57.0"
+    eslint: "npm:^9.9.0"
     eslint-plugin-sc-js: "workspace:^"
     fixpack: "npm:^4.0.0"
     npm-run-all2: "npm:^6.2.2"
@@ -4550,6 +4598,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-scope@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "eslint-scope@npm:8.0.2"
+  dependencies:
+    esrecurse: "npm:^4.3.0"
+    estraverse: "npm:^5.2.0"
+  checksum: 10c0/477f820647c8755229da913025b4567347fd1f0bf7cbdf3a256efff26a7e2e130433df052bd9e3d014025423dc00489bea47eb341002b15553673379c1a7dc36
+  languageName: node
+  linkType: hard
+
 "eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
   version: 3.4.3
   resolution: "eslint-visitor-keys@npm:3.4.3"
@@ -4612,6 +4670,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint@npm:^9.9.0":
+  version: 9.9.0
+  resolution: "eslint@npm:9.9.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.2.0"
+    "@eslint-community/regexpp": "npm:^4.11.0"
+    "@eslint/config-array": "npm:^0.17.1"
+    "@eslint/eslintrc": "npm:^3.1.0"
+    "@eslint/js": "npm:9.9.0"
+    "@humanwhocodes/module-importer": "npm:^1.0.1"
+    "@humanwhocodes/retry": "npm:^0.3.0"
+    "@nodelib/fs.walk": "npm:^1.2.8"
+    ajv: "npm:^6.12.4"
+    chalk: "npm:^4.0.0"
+    cross-spawn: "npm:^7.0.2"
+    debug: "npm:^4.3.2"
+    escape-string-regexp: "npm:^4.0.0"
+    eslint-scope: "npm:^8.0.2"
+    eslint-visitor-keys: "npm:^4.0.0"
+    espree: "npm:^10.1.0"
+    esquery: "npm:^1.5.0"
+    esutils: "npm:^2.0.2"
+    fast-deep-equal: "npm:^3.1.3"
+    file-entry-cache: "npm:^8.0.0"
+    find-up: "npm:^5.0.0"
+    glob-parent: "npm:^6.0.2"
+    ignore: "npm:^5.2.0"
+    imurmurhash: "npm:^0.1.4"
+    is-glob: "npm:^4.0.0"
+    is-path-inside: "npm:^3.0.3"
+    json-stable-stringify-without-jsonify: "npm:^1.0.1"
+    levn: "npm:^0.4.1"
+    lodash.merge: "npm:^4.6.2"
+    minimatch: "npm:^3.1.2"
+    natural-compare: "npm:^1.4.0"
+    optionator: "npm:^0.9.3"
+    strip-ansi: "npm:^6.0.1"
+    text-table: "npm:^0.2.0"
+  peerDependencies:
+    jiti: "*"
+  peerDependenciesMeta:
+    jiti:
+      optional: true
+  bin:
+    eslint: bin/eslint.js
+  checksum: 10c0/3a22f68c99d75dcbafe6e2fef18d2b5bbcc960c2437f48a414ccf9ca214254733a18e6b79d07bbd374a2369a648413e421aabd07b11be3de5a44d5a4b9997877
+  languageName: node
+  linkType: hard
+
 "espree@npm:^10.0.1":
   version: 10.0.1
   resolution: "espree@npm:10.0.1"
@@ -4620,6 +4727,17 @@ __metadata:
     acorn-jsx: "npm:^5.3.2"
     eslint-visitor-keys: "npm:^4.0.0"
   checksum: 10c0/7c0f84afa0f9db7bb899619e6364ed832ef13fe8943691757ddde9a1805ae68b826ed66803323015f707a629a5507d0d290edda2276c25131fe0ad883b8b5636
+  languageName: node
+  linkType: hard
+
+"espree@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "espree@npm:10.1.0"
+  dependencies:
+    acorn: "npm:^8.12.0"
+    acorn-jsx: "npm:^5.3.2"
+    eslint-visitor-keys: "npm:^4.0.0"
+  checksum: 10c0/52e6feaa77a31a6038f0c0e3fce93010a4625701925b0715cd54a2ae190b3275053a0717db698697b32653788ac04845e489d6773b508d6c2e8752f3c57470a0
   languageName: node
   linkType: hard
 
@@ -4836,6 +4954,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-entry-cache@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "file-entry-cache@npm:8.0.0"
+  dependencies:
+    flat-cache: "npm:^4.0.0"
+  checksum: 10c0/9e2b5938b1cd9b6d7e3612bdc533afd4ac17b2fc646569e9a8abbf2eb48e5eb8e316bc38815a3ef6a1b456f4107f0d0f055a614ca613e75db6bf9ff4d72c1638
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^9.0.0":
   version: 9.0.0
   resolution: "file-entry-cache@npm:9.0.0"
@@ -4925,6 +5052,16 @@ __metadata:
     keyv: "npm:^4.5.3"
     rimraf: "npm:^3.0.2"
   checksum: 10c0/b76f611bd5f5d68f7ae632e3ae503e678d205cf97a17c6ab5b12f6ca61188b5f1f7464503efae6dc18683ed8f0b41460beb48ac4b9ac63fe6201296a91ba2f75
+  languageName: node
+  linkType: hard
+
+"flat-cache@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "flat-cache@npm:4.0.1"
+  dependencies:
+    flatted: "npm:^3.2.9"
+    keyv: "npm:^4.5.4"
+  checksum: 10c0/2c59d93e9faa2523e4fda6b4ada749bed432cfa28c8e251f33b25795e426a1c6dbada777afb1f74fcfff33934fdbdea921ee738fcc33e71adc9d6eca984a1cfc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Features
- support eslint v9
- support package related typescript-eslint to v8

### file-path-patterns
- deprecate regular expression array of `allowPatterns`.
- support string array that be able to hands over to RegExp of `allowPatterns`.

### match-names-of-file-and-export
- deprecate regular expression array of `captures`.
- support string array that be able to hands over to RegExp of `captures`.