### PR TITLE
ルールの調整 + α

### DIFF
--- a/dry-run/dr-eslint-config-sc-all/sample/ts-jest/src/index.ts
+++ b/dry-run/dr-eslint-config-sc-all/sample/ts-jest/src/index.ts
@@ -55,7 +55,7 @@ const function4 = () => {
 
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   const a: number | unknown = 1
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion
   return a as number
 }
 

--- a/dry-run/dr-eslint-config-sc-all/sample/ts/src/index.ts
+++ b/dry-run/dr-eslint-config-sc-all/sample/ts/src/index.ts
@@ -55,7 +55,7 @@ const function4 = () => {
 
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   const a: number | unknown = 1
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unsafe-type-assertion
   return a as number
 }
 

--- a/packages/eslint-config-react/src/shared/config/rules/typescriptRules/rules/typescriptEslint/options/namingConvention/index.ts
+++ b/packages/eslint-config-react/src/shared/config/rules/typescriptRules/rules/typescriptEslint/options/namingConvention/index.ts
@@ -51,4 +51,9 @@ export const namingConvention = [
 
     format: ["PascalCase"],
   },
+  {
+    selector: "class",
+
+    format: ["PascalCase"],
+  },
 ] as const satisfies EslintRuleLevelAndOptions

--- a/packages/eslint-config-ts/src/shared/config/rules/baseRules/rules/typescriptEslintRules/options/namingConvention/index.ts
+++ b/packages/eslint-config-ts/src/shared/config/rules/baseRules/rules/typescriptEslintRules/options/namingConvention/index.ts
@@ -25,7 +25,7 @@ export const namingConvention = [
   {
     selector: ["variable", "objectLiteralProperty"],
 
-    format: ["camelCase", "UPPER_CASE"],
+    format: ["camelCase", "UPPER_CASE", "PascalCase"],
     leadingUnderscore: "allow",
     trailingUnderscore: "forbid",
   },
@@ -40,6 +40,11 @@ export const namingConvention = [
 
   {
     selector: "typeLike",
+
+    format: ["PascalCase"],
+  },
+  {
+    selector: "class",
 
     format: ["PascalCase"],
   },


### PR DESCRIPTION
- @typescript-eslint/no-unsafe-type-assertion の調整
  - closes: https://github.com/akky-xxxx/strict-check/issues/105
- https://github.com/akky-xxxx/strict-check/pull/124 の対応漏れ