### PR TITLE
eslint-plugin-import の導入

### DIFF
--- a/dry-run/dr-eslint-config-sc-js/tests/flat/js-test-sub1.js
+++ b/dry-run/dr-eslint-config-sc-js/tests/flat/js-test-sub1.js
@@ -1,0 +1,7 @@
+/* eslint-disable import/no-deprecated */
+// eslint-disable-next-line import/no-cycle
+import { sub2 } from "./js-test-sub2"
+
+export const sub1 = () => {
+  sub2()
+}

--- a/dry-run/dr-eslint-config-sc-js/tests/flat/js-test-sub2.js
+++ b/dry-run/dr-eslint-config-sc-js/tests/flat/js-test-sub2.js
@@ -1,0 +1,9 @@
+// eslint-disable-next-line import/no-cycle
+import { sub1 } from "./js-test-sub1"
+
+/**
+ * @deprecated test
+ */
+export const sub2 = () => {
+  sub1()
+}

--- a/dry-run/dr-eslint-config-sc-js/tests/flat/js-test.js
+++ b/dry-run/dr-eslint-config-sc-js/tests/flat/js-test.js
@@ -247,3 +247,9 @@ const object4 = {
   // eslint-disable-next-line @stylistic/indent
     a: 1,
 }
+
+// eslint-disable-next-line import/no-empty-named-blocks, import/no-useless-path-segments, import/first
+import {} from "../flat/js-test-sub1"
+
+// eslint-disable-next-line import/no-mutable-exports, prefer-const
+export let variable6 = "a"

--- a/packages/eslint-config-all/spec/tests/getConfigs/modules/getConfigsBase/index.test.ts
+++ b/packages/eslint-config-all/spec/tests/getConfigs/modules/getConfigsBase/index.test.ts
@@ -4,84 +4,88 @@ import { getConfigsBase } from "../../../../../src/getConfigs/modules/getConfigs
 describe("getConfigsBase", () => {
   describe("javascript", () => {
     const result = getConfigsBase("javascript")
-    it("getConfigsBase の戻り値は配列長7", () => {
-      expect(result).toHaveLength(7)
+    it("getConfigsBase の戻り値は配列長8", () => {
+      expect(result).toHaveLength(8)
     })
     it.each([
       [0, "eslint-config-sc-js/initialRecord"],
-      [1, "eslint-config-sc-js/stylisticRecord"],
-      [2, "eslint-config-sc-js/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-js/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-js/airbnbBaseRecords"],
-      [5, "eslint-config-sc-js/customRecord"],
-      [6, "eslint-config-sc-js/resetRecordForStylistic"],
+      [1, "eslint-config-sc-js/importRecommendedRecord"],
+      [2, "eslint-config-sc-js/stylisticRecord"],
+      [3, "eslint-config-sc-js/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-js/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-js/airbnbBaseRecords"],
+      [6, "eslint-config-sc-js/customRecord"],
+      [7, "eslint-config-sc-js/resetRecordForStylistic"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
   })
   describe("javascript with jest, storybook", () => {
     const result = getConfigsBase("javascript", ["jest", "storybook"])
-    it("getConfigsBase の戻り値は配列長12", () => {
-      expect(result).toHaveLength(12)
+    it("getConfigsBase の戻り値は配列長13", () => {
+      expect(result).toHaveLength(13)
     })
     it.each([
       [0, "eslint-config-sc-js/initialRecord"],
-      [1, "eslint-config-sc-js/stylisticRecord"],
-      [2, "eslint-config-sc-js/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-js/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-js/airbnbBaseRecords"],
-      [5, "eslint-config-sc-js/customRecord"],
-      [6, "eslint-config-sc-storybook/storybookConfigRecords"],
-      [7, "eslint-config-sc-storybook/overrideJavascriptRecord"],
-      [8, "eslint-config-sc-jest/jestPluginRecords"],
-      [9, "eslint-config-sc-jest/customRecord"],
-      [10, "eslint-config-sc-jest/overrideJavascriptRecord"],
-      [11, "eslint-config-sc-js/resetRecordForStylistic"],
+      [1, "eslint-config-sc-js/importRecommendedRecord"],
+      [2, "eslint-config-sc-js/stylisticRecord"],
+      [3, "eslint-config-sc-js/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-js/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-js/airbnbBaseRecords"],
+      [6, "eslint-config-sc-js/customRecord"],
+      [7, "eslint-config-sc-storybook/storybookConfigRecords"],
+      [8, "eslint-config-sc-storybook/overrideJavascriptRecord"],
+      [9, "eslint-config-sc-jest/jestPluginRecords"],
+      [10, "eslint-config-sc-jest/customRecord"],
+      [11, "eslint-config-sc-jest/overrideJavascriptRecord"],
+      [12, "eslint-config-sc-js/resetRecordForStylistic"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
   })
   describe("typescript", () => {
     const result = getConfigsBase("typescript")
-    it("getConfigsBase の戻り値は配列長10", () => {
-      expect(result).toHaveLength(10)
+    it("getConfigsBase の戻り値は配列長11", () => {
+      expect(result).toHaveLength(11)
     })
     it.each([
       [0, "eslint-config-sc-ts/initialRecord"],
-      [1, "eslint-config-sc-ts/stylisticRecord"],
-      [2, "eslint-config-sc-ts/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-ts/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
-      [5, "eslint-config-sc-ts/typescriptEslintStylisticTypeCheckedRecords"],
-      [6, "eslint-config-sc-ts/airbnbBaseRecords"],
-      [7, "eslint-config-sc-ts/scJsCustomRecord"],
-      [8, "eslint-config-sc-ts/customRecord"],
-      [9, "eslint-config-sc-ts/resetRecordForStylistic"],
+      [1, "eslint-config-sc-ts/importRecommendedRecord"],
+      [2, "eslint-config-sc-ts/stylisticRecord"],
+      [3, "eslint-config-sc-ts/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-ts/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
+      [6, "eslint-config-sc-ts/typescriptEslintStylisticTypeCheckedRecords"],
+      [7, "eslint-config-sc-ts/airbnbBaseRecords"],
+      [8, "eslint-config-sc-ts/scJsCustomRecord"],
+      [9, "eslint-config-sc-ts/customRecord"],
+      [10, "eslint-config-sc-ts/resetRecordForStylistic"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
   })
   describe("typescript with jest, storybook", () => {
     const result = getConfigsBase("typescript", ["jest", "storybook"])
-    it("getConfigsBase の戻り値は配列長15", () => {
-      expect(result).toHaveLength(15)
+    it("getConfigsBase の戻り値は配列長16", () => {
+      expect(result).toHaveLength(16)
     })
     it.each([
       [0, "eslint-config-sc-ts/initialRecord"],
-      [1, "eslint-config-sc-ts/stylisticRecord"],
-      [2, "eslint-config-sc-ts/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-ts/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
-      [5, "eslint-config-sc-ts/typescriptEslintStylisticTypeCheckedRecords"],
-      [6, "eslint-config-sc-ts/airbnbBaseRecords"],
-      [7, "eslint-config-sc-ts/scJsCustomRecord"],
-      [8, "eslint-config-sc-ts/customRecord"],
-      [9, "eslint-config-sc-storybook/storybookConfigRecords"],
-      [10, "eslint-config-sc-storybook/overrideTypescriptRecord"],
-      [11, "eslint-config-sc-jest/jestPluginRecords"],
-      [12, "eslint-config-sc-jest/customRecord"],
-      [13, "eslint-config-sc-jest/overrideTypescriptRecord"],
-      [14, "eslint-config-sc-ts/resetRecordForStylistic"],
+      [1, "eslint-config-sc-ts/importRecommendedRecord"],
+      [2, "eslint-config-sc-ts/stylisticRecord"],
+      [3, "eslint-config-sc-ts/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-ts/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
+      [6, "eslint-config-sc-ts/typescriptEslintStylisticTypeCheckedRecords"],
+      [7, "eslint-config-sc-ts/airbnbBaseRecords"],
+      [8, "eslint-config-sc-ts/scJsCustomRecord"],
+      [9, "eslint-config-sc-ts/customRecord"],
+      [10, "eslint-config-sc-storybook/storybookConfigRecords"],
+      [11, "eslint-config-sc-storybook/overrideTypescriptRecord"],
+      [12, "eslint-config-sc-jest/jestPluginRecords"],
+      [13, "eslint-config-sc-jest/customRecord"],
+      [14, "eslint-config-sc-jest/overrideTypescriptRecord"],
+      [15, "eslint-config-sc-ts/resetRecordForStylistic"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })

--- a/packages/eslint-config-all/spec/tests/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForJavascript/index.test.ts
+++ b/packages/eslint-config-all/spec/tests/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForJavascript/index.test.ts
@@ -4,36 +4,15 @@ import { getConfigName } from "../getConfigName"
 describe("getConfigsBaseForJavascript", () => {
   describe("javascript with react", () => {
     const result = getConfigsBaseForJavascript(["react"])
-    it("getConfigsBaseForJavascript の戻り値は配列長10", () => {
-      expect(result).toHaveLength(11)
-    })
-    it.each([
-      [0, "eslint-config-sc-js/initialRecord"],
-      [1, "eslint-config-sc-js/stylisticRecord"],
-      [2, "eslint-config-sc-js/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-js/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-react/initialRecord"],
-      [5, "eslint-config-sc-react/airbnbRecords"],
-      [6, "eslint-config-sc-react/reactRecords"],
-      [7, "eslint-config-sc-react/scJsCustomRecord"],
-      [8, "eslint-config-sc-js/customRecord"],
-      [9, "eslint-config-sc-react/customRecord"],
-      [10, "eslint-config-sc-js/resetRecordForStylistic"],
-    ] as const)("%i番目の config の name は「%s」", (index, name) => {
-      expect(getConfigName(result[index])).toBe(name)
-    })
-  })
-  describe("javascript with react, next", () => {
-    const result = getConfigsBaseForJavascript(["next", "react"])
-    it("getConfigsBaseForJavascript の戻り値は配列長11", () => {
+    it("getConfigsBaseForJavascript の戻り値は配列長12", () => {
       expect(result).toHaveLength(12)
     })
     it.each([
       [0, "eslint-config-sc-js/initialRecord"],
-      [1, "eslint-config-sc-js/stylisticRecord"],
-      [2, "eslint-config-sc-js/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-js/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-next/nextRecord"],
+      [1, "eslint-config-sc-js/importRecommendedRecord"],
+      [2, "eslint-config-sc-js/stylisticRecord"],
+      [3, "eslint-config-sc-js/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-js/unicornRecommendedRecords"],
       [5, "eslint-config-sc-react/initialRecord"],
       [6, "eslint-config-sc-react/airbnbRecords"],
       [7, "eslint-config-sc-react/reactRecords"],
@@ -45,53 +24,78 @@ describe("getConfigsBaseForJavascript", () => {
       expect(getConfigName(result[index])).toBe(name)
     })
   })
-  describe("javascript with react, next, storybook", () => {
-    const result = getConfigsBaseForJavascript(["next", "react", "storybook"])
+  describe("javascript with react, next", () => {
+    const result = getConfigsBaseForJavascript(["next", "react"])
     it("getConfigsBaseForJavascript の戻り値は配列長13", () => {
-      expect(result).toHaveLength(14)
+      expect(result).toHaveLength(13)
     })
     it.each([
       [0, "eslint-config-sc-js/initialRecord"],
-      [1, "eslint-config-sc-js/stylisticRecord"],
-      [2, "eslint-config-sc-js/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-js/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-next/nextRecord"],
-      [5, "eslint-config-sc-react/initialRecord"],
-      [6, "eslint-config-sc-react/airbnbRecords"],
-      [7, "eslint-config-sc-react/reactRecords"],
-      [8, "eslint-config-sc-react/scJsCustomRecord"],
-      [9, "eslint-config-sc-js/customRecord"],
-      [10, "eslint-config-sc-react/customRecord"],
-      [11, "eslint-config-sc-storybook/storybookConfigRecords"],
-      [12, "eslint-config-sc-storybook/overrideJavascriptRecord"],
-      [13, "eslint-config-sc-js/resetRecordForStylistic"],
+      [1, "eslint-config-sc-js/importRecommendedRecord"],
+      [2, "eslint-config-sc-js/stylisticRecord"],
+      [3, "eslint-config-sc-js/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-js/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-next/nextRecord"],
+      [6, "eslint-config-sc-react/initialRecord"],
+      [7, "eslint-config-sc-react/airbnbRecords"],
+      [8, "eslint-config-sc-react/reactRecords"],
+      [9, "eslint-config-sc-react/scJsCustomRecord"],
+      [10, "eslint-config-sc-js/customRecord"],
+      [11, "eslint-config-sc-react/customRecord"],
+      [12, "eslint-config-sc-js/resetRecordForStylistic"],
+    ] as const)("%i番目の config の name は「%s」", (index, name) => {
+      expect(getConfigName(result[index])).toBe(name)
+    })
+  })
+  describe("javascript with react, next, storybook", () => {
+    const result = getConfigsBaseForJavascript(["next", "react", "storybook"])
+    it("getConfigsBaseForJavascript の戻り値は配列長15", () => {
+      expect(result).toHaveLength(15)
+    })
+    it.each([
+      [0, "eslint-config-sc-js/initialRecord"],
+      [1, "eslint-config-sc-js/importRecommendedRecord"],
+      [2, "eslint-config-sc-js/stylisticRecord"],
+      [3, "eslint-config-sc-js/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-js/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-next/nextRecord"],
+      [6, "eslint-config-sc-react/initialRecord"],
+      [7, "eslint-config-sc-react/airbnbRecords"],
+      [8, "eslint-config-sc-react/reactRecords"],
+      [9, "eslint-config-sc-react/scJsCustomRecord"],
+      [10, "eslint-config-sc-js/customRecord"],
+      [11, "eslint-config-sc-react/customRecord"],
+      [12, "eslint-config-sc-storybook/storybookConfigRecords"],
+      [13, "eslint-config-sc-storybook/overrideJavascriptRecord"],
+      [14, "eslint-config-sc-js/resetRecordForStylistic"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
   })
   describe("javascript with react, next, storybook, jest", () => {
     const result = getConfigsBaseForJavascript(["next", "react", "storybook", "jest"])
-    it("getConfigsBaseForJavascript の戻り値は配列長16", () => {
-      expect(result).toHaveLength(17)
+    it("getConfigsBaseForJavascript の戻り値は配列長18", () => {
+      expect(result).toHaveLength(18)
     })
     it.each([
       [0, "eslint-config-sc-js/initialRecord"],
-      [1, "eslint-config-sc-js/stylisticRecord"],
-      [2, "eslint-config-sc-js/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-js/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-next/nextRecord"],
-      [5, "eslint-config-sc-react/initialRecord"],
-      [6, "eslint-config-sc-react/airbnbRecords"],
-      [7, "eslint-config-sc-react/reactRecords"],
-      [8, "eslint-config-sc-react/scJsCustomRecord"],
-      [9, "eslint-config-sc-js/customRecord"],
-      [10, "eslint-config-sc-react/customRecord"],
-      [11, "eslint-config-sc-storybook/storybookConfigRecords"],
-      [12, "eslint-config-sc-storybook/overrideJavascriptRecord"],
-      [13, "eslint-config-sc-jest/jestPluginRecords"],
-      [14, "eslint-config-sc-jest/customRecord"],
-      [15, "eslint-config-sc-jest/overrideJavascriptRecord"],
-      [16, "eslint-config-sc-js/resetRecordForStylistic"],
+      [1, "eslint-config-sc-js/importRecommendedRecord"],
+      [2, "eslint-config-sc-js/stylisticRecord"],
+      [3, "eslint-config-sc-js/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-js/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-next/nextRecord"],
+      [6, "eslint-config-sc-react/initialRecord"],
+      [7, "eslint-config-sc-react/airbnbRecords"],
+      [8, "eslint-config-sc-react/reactRecords"],
+      [9, "eslint-config-sc-react/scJsCustomRecord"],
+      [10, "eslint-config-sc-js/customRecord"],
+      [11, "eslint-config-sc-react/customRecord"],
+      [12, "eslint-config-sc-storybook/storybookConfigRecords"],
+      [13, "eslint-config-sc-storybook/overrideJavascriptRecord"],
+      [14, "eslint-config-sc-jest/jestPluginRecords"],
+      [15, "eslint-config-sc-jest/customRecord"],
+      [16, "eslint-config-sc-jest/overrideJavascriptRecord"],
+      [17, "eslint-config-sc-js/resetRecordForStylistic"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })

--- a/packages/eslint-config-all/spec/tests/getConfigs/modules/getConfigsBase/modules/getConfigsBaseTypescript/index.test.ts
+++ b/packages/eslint-config-all/spec/tests/getConfigs/modules/getConfigsBase/modules/getConfigsBaseTypescript/index.test.ts
@@ -4,42 +4,17 @@ import { getConfigName } from "../getConfigName"
 describe("getConfigsBaseForTypescript", () => {
   describe("typescript with react", () => {
     const result = getConfigsBaseForTypescript(["react"])
-    it("getConfigsBaseForTypescript の戻り値は配列長14", () => {
-      expect(result).toHaveLength(15)
-    })
-    it.each([
-      [0, "eslint-config-sc-ts/initialRecord"],
-      [1, "eslint-config-sc-ts/stylisticRecord"],
-      [2, "eslint-config-sc-ts/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-ts/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
-      [5, "eslint-config-sc-ts/typescriptEslintStylisticTypeCheckedRecords"],
-      [6, "eslint-config-sc-react/initialRecord"],
-      [7, "eslint-config-sc-react/airbnbRecords"],
-      [8, "eslint-config-sc-react/reactRecords"],
-      [9, "eslint-config-sc-react/scJsCustomRecord"],
-      [10, "eslint-config-sc-ts/scJsCustomRecord"],
-      [11, "eslint-config-sc-ts/customRecord"],
-      [12, "eslint-config-sc-react/customRecord"],
-      [13, "eslint-config-sc-react/customRecordWithTypescript"],
-      [14, "eslint-config-sc-ts/resetRecordForStylistic"],
-    ] as const)("%i番目の config の name は「%s」", (index, name) => {
-      expect(getConfigName(result[index])).toBe(name)
-    })
-  })
-  describe("typescript with react, next", () => {
-    const result = getConfigsBaseForTypescript(["next", "react"])
-    it("getConfigsBaseForTypescript の戻り値は配列長15", () => {
+    it("getConfigsBaseForTypescript の戻り値は配列長16", () => {
       expect(result).toHaveLength(16)
     })
     it.each([
       [0, "eslint-config-sc-ts/initialRecord"],
-      [1, "eslint-config-sc-ts/stylisticRecord"],
-      [2, "eslint-config-sc-ts/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-ts/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
-      [5, "eslint-config-sc-ts/typescriptEslintStylisticTypeCheckedRecords"],
-      [6, "eslint-config-sc-next/nextRecord"],
+      [1, "eslint-config-sc-ts/importRecommendedRecord"],
+      [2, "eslint-config-sc-ts/stylisticRecord"],
+      [3, "eslint-config-sc-ts/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-ts/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
+      [6, "eslint-config-sc-ts/typescriptEslintStylisticTypeCheckedRecords"],
       [7, "eslint-config-sc-react/initialRecord"],
       [8, "eslint-config-sc-react/airbnbRecords"],
       [9, "eslint-config-sc-react/reactRecords"],
@@ -53,61 +28,90 @@ describe("getConfigsBaseForTypescript", () => {
       expect(getConfigName(result[index])).toBe(name)
     })
   })
-  describe("typescript with react, next, storybook", () => {
-    const result = getConfigsBaseForTypescript(["next", "react", "storybook"])
+  describe("typescript with react, next", () => {
+    const result = getConfigsBaseForTypescript(["next", "react"])
     it("getConfigsBaseForTypescript の戻り値は配列長17", () => {
-      expect(result).toHaveLength(18)
+      expect(result).toHaveLength(17)
     })
     it.each([
       [0, "eslint-config-sc-ts/initialRecord"],
-      [1, "eslint-config-sc-ts/stylisticRecord"],
-      [2, "eslint-config-sc-ts/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-ts/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
-      [5, "eslint-config-sc-ts/typescriptEslintStylisticTypeCheckedRecords"],
-      [6, "eslint-config-sc-next/nextRecord"],
-      [7, "eslint-config-sc-react/initialRecord"],
-      [8, "eslint-config-sc-react/airbnbRecords"],
-      [9, "eslint-config-sc-react/reactRecords"],
-      [10, "eslint-config-sc-react/scJsCustomRecord"],
-      [11, "eslint-config-sc-ts/scJsCustomRecord"],
-      [12, "eslint-config-sc-ts/customRecord"],
-      [13, "eslint-config-sc-react/customRecord"],
-      [14, "eslint-config-sc-react/customRecordWithTypescript"],
-      [15, "eslint-config-sc-storybook/storybookConfigRecords"],
-      [16, "eslint-config-sc-storybook/overrideTypescriptRecord"],
-      [17, "eslint-config-sc-ts/resetRecordForStylistic"],
+      [1, "eslint-config-sc-ts/importRecommendedRecord"],
+      [2, "eslint-config-sc-ts/stylisticRecord"],
+      [3, "eslint-config-sc-ts/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-ts/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
+      [6, "eslint-config-sc-ts/typescriptEslintStylisticTypeCheckedRecords"],
+      [7, "eslint-config-sc-next/nextRecord"],
+      [8, "eslint-config-sc-react/initialRecord"],
+      [9, "eslint-config-sc-react/airbnbRecords"],
+      [10, "eslint-config-sc-react/reactRecords"],
+      [11, "eslint-config-sc-react/scJsCustomRecord"],
+      [12, "eslint-config-sc-ts/scJsCustomRecord"],
+      [13, "eslint-config-sc-ts/customRecord"],
+      [14, "eslint-config-sc-react/customRecord"],
+      [15, "eslint-config-sc-react/customRecordWithTypescript"],
+      [16, "eslint-config-sc-ts/resetRecordForStylistic"],
+    ] as const)("%i番目の config の name は「%s」", (index, name) => {
+      expect(getConfigName(result[index])).toBe(name)
+    })
+  })
+  describe("typescript with react, next, storybook", () => {
+    const result = getConfigsBaseForTypescript(["next", "react", "storybook"])
+    it("getConfigsBaseForTypescript の戻り値は配列長19", () => {
+      expect(result).toHaveLength(19)
+    })
+    it.each([
+      [0, "eslint-config-sc-ts/initialRecord"],
+      [1, "eslint-config-sc-ts/importRecommendedRecord"],
+      [2, "eslint-config-sc-ts/stylisticRecord"],
+      [3, "eslint-config-sc-ts/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-ts/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
+      [6, "eslint-config-sc-ts/typescriptEslintStylisticTypeCheckedRecords"],
+      [7, "eslint-config-sc-next/nextRecord"],
+      [8, "eslint-config-sc-react/initialRecord"],
+      [9, "eslint-config-sc-react/airbnbRecords"],
+      [10, "eslint-config-sc-react/reactRecords"],
+      [11, "eslint-config-sc-react/scJsCustomRecord"],
+      [12, "eslint-config-sc-ts/scJsCustomRecord"],
+      [13, "eslint-config-sc-ts/customRecord"],
+      [14, "eslint-config-sc-react/customRecord"],
+      [15, "eslint-config-sc-react/customRecordWithTypescript"],
+      [16, "eslint-config-sc-storybook/storybookConfigRecords"],
+      [17, "eslint-config-sc-storybook/overrideTypescriptRecord"],
+      [18, "eslint-config-sc-ts/resetRecordForStylistic"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
   })
   describe("typescript with react, next, storybook, jest", () => {
     const result = getConfigsBaseForTypescript(["next", "react", "storybook", "jest"])
-    it("getConfigsBaseForTypescript の戻り値は配列長20", () => {
-      expect(result).toHaveLength(21)
+    it("getConfigsBaseForTypescript の戻り値は配列長22", () => {
+      expect(result).toHaveLength(22)
     })
     it.each([
       [0, "eslint-config-sc-ts/initialRecord"],
-      [1, "eslint-config-sc-ts/stylisticRecord"],
-      [2, "eslint-config-sc-ts/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-ts/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
-      [5, "eslint-config-sc-ts/typescriptEslintStylisticTypeCheckedRecords"],
-      [6, "eslint-config-sc-next/nextRecord"],
-      [7, "eslint-config-sc-react/initialRecord"],
-      [8, "eslint-config-sc-react/airbnbRecords"],
-      [9, "eslint-config-sc-react/reactRecords"],
-      [10, "eslint-config-sc-react/scJsCustomRecord"],
-      [11, "eslint-config-sc-ts/scJsCustomRecord"],
-      [12, "eslint-config-sc-ts/customRecord"],
-      [13, "eslint-config-sc-react/customRecord"],
-      [14, "eslint-config-sc-react/customRecordWithTypescript"],
-      [15, "eslint-config-sc-storybook/storybookConfigRecords"],
-      [16, "eslint-config-sc-storybook/overrideTypescriptRecord"],
-      [17, "eslint-config-sc-jest/jestPluginRecords"],
-      [18, "eslint-config-sc-jest/customRecord"],
-      [19, "eslint-config-sc-jest/overrideTypescriptRecord"],
-      [20, "eslint-config-sc-ts/resetRecordForStylistic"],
+      [1, "eslint-config-sc-ts/importRecommendedRecord"],
+      [2, "eslint-config-sc-ts/stylisticRecord"],
+      [3, "eslint-config-sc-ts/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-ts/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
+      [6, "eslint-config-sc-ts/typescriptEslintStylisticTypeCheckedRecords"],
+      [7, "eslint-config-sc-next/nextRecord"],
+      [8, "eslint-config-sc-react/initialRecord"],
+      [9, "eslint-config-sc-react/airbnbRecords"],
+      [10, "eslint-config-sc-react/reactRecords"],
+      [11, "eslint-config-sc-react/scJsCustomRecord"],
+      [12, "eslint-config-sc-ts/scJsCustomRecord"],
+      [13, "eslint-config-sc-ts/customRecord"],
+      [14, "eslint-config-sc-react/customRecord"],
+      [15, "eslint-config-sc-react/customRecordWithTypescript"],
+      [16, "eslint-config-sc-storybook/storybookConfigRecords"],
+      [17, "eslint-config-sc-storybook/overrideTypescriptRecord"],
+      [18, "eslint-config-sc-jest/jestPluginRecords"],
+      [19, "eslint-config-sc-jest/customRecord"],
+      [20, "eslint-config-sc-jest/overrideTypescriptRecord"],
+      [21, "eslint-config-sc-ts/resetRecordForStylistic"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })

--- a/packages/eslint-config-all/src/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForJavascript/index.ts
+++ b/packages/eslint-config-all/src/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForJavascript/index.ts
@@ -12,6 +12,7 @@ export const getConfigsBaseForJavascript: GetConfigsBaseForJavascript = (librari
   const jsConfig = require("eslint-config-sc-js")
   configBase.push(
     jsConfig.configs.initialRecord,
+    jsConfig.configs.importRecommendedRecord,
     jsConfig.configs.stylisticRecord,
     jsConfig.configs.eslintRecommendedRecord,
     jsConfig.configs.unicornRecommendedRecords,

--- a/packages/eslint-config-all/src/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForTypescript/index.ts
+++ b/packages/eslint-config-all/src/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForTypescript/index.ts
@@ -12,6 +12,7 @@ export const getConfigsBaseForTypescript: GetConfigsBaseForTypescript = (librari
   const tsConfig = require("eslint-config-sc-ts")
   configBase.push(
     tsConfig.configs.initialRecord,
+    tsConfig.configs.importRecommendedRecord,
     tsConfig.configs.stylisticRecord,
     tsConfig.configs.eslintRecommendedRecord,
     tsConfig.configs.unicornRecommendedRecords,

--- a/packages/eslint-config-js/package.json
+++ b/packages/eslint-config-js/package.json
@@ -51,6 +51,7 @@
     "cspell": "^9.1.2",
     "editorconfig-checker": "^6.0.1",
     "eslint": "^9.30.0",
+    "eslint-plugin-import": "^2.32.0",
     "fixpack": "^4.0.0",
     "npm-run-all2": "^8.0.4",
     "prettier": "^3.6.2",
@@ -63,6 +64,7 @@
     "@eslint/js": ">=9.30.0",
     "@stylistic/eslint-plugin": ">=5.1.0",
     "eslint-config-airbnb-base": ">=15.0.0",
+    "eslint-plugin-import": ">=2.32.0",
     "eslint-plugin-unicorn": ">=59.0.1"
   },
   "packageManager": "yarn@4.2.2"

--- a/packages/eslint-config-js/src/flatConfig/index.ts
+++ b/packages/eslint-config-js/src/flatConfig/index.ts
@@ -1,6 +1,7 @@
 import { airbnbBaseRecords } from "../shared/config/records/airbnbBaseRecords"
 import { customRecord } from "../shared/config/records/customRecord"
 import { eslintRecommendedRecord } from "../shared/config/records/eslintRecommendedRecord"
+import { importRecommendedRecord } from "../shared/config/records/importRecommendedRecord"
 import { initialRecord } from "../shared/config/records/initialRecord"
 import { resetRecordForStylistic } from "../shared/config/records/resetRecordForStylistic"
 import { stylisticRecord } from "../shared/config/records/stylisticRecord"
@@ -10,6 +11,7 @@ import type { EslintFlatConfig } from "../libs/shared-for-config/types/EslintFla
 
 export const flatConfig = [
   initialRecord,
+  importRecommendedRecord,
   stylisticRecord,
   eslintRecommendedRecord,
   unicornRecommendedRecords,

--- a/packages/eslint-config-js/src/index.ts
+++ b/packages/eslint-config-js/src/index.ts
@@ -2,6 +2,7 @@ import { flatConfig } from "./flatConfig"
 import { airbnbBaseRecords } from "./shared/config/records/airbnbBaseRecords"
 import { customRecord } from "./shared/config/records/customRecord"
 import { eslintRecommendedRecord } from "./shared/config/records/eslintRecommendedRecord"
+import { importRecommendedRecord } from "./shared/config/records/importRecommendedRecord"
 import { initialRecord } from "./shared/config/records/initialRecord"
 import { resetRecordForStylistic } from "./shared/config/records/resetRecordForStylistic"
 import { stylisticRecord } from "./shared/config/records/stylisticRecord"
@@ -20,6 +21,7 @@ const plugin = {
 
     airbnbBaseRecords,
     eslintRecommendedRecord,
+    importRecommendedRecord,
     initialRecord,
     stylisticRecord,
     unicornRecommendedRecords,

--- a/packages/eslint-config-js/src/shared/config/records/importRecommendedRecord/index.ts
+++ b/packages/eslint-config-js/src/shared/config/records/importRecommendedRecord/index.ts
@@ -1,0 +1,16 @@
+import { PACKAGE_NAME } from "../../../constants/PACKAGE_NAME"
+
+import type { EslintFlatConfig } from "../../../../libs/shared-for-config/types/EslintFlatConfig"
+
+// cjs 形式のため
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const eslintPluginImport = require("eslint-plugin-import")
+
+export const importRecommendedRecord = {
+  ...eslintPluginImport.flatConfigs.recommended,
+  ...eslintPluginImport.flatConfigs.typescript,
+  name: `${PACKAGE_NAME}/importRecommendedRecord`,
+  plugins: {
+    import: eslintPluginImport,
+  },
+} as const satisfies EslintFlatConfig

--- a/packages/eslint-config-js/src/shared/config/rules/baseRules/rules/importRules/index.ts
+++ b/packages/eslint-config-js/src/shared/config/rules/baseRules/rules/importRules/index.ts
@@ -5,8 +5,14 @@ import { SEVERITY } from "../../../../../../libs/shared-for-config/constants/SEV
 import type { EslintRules } from "../../../../../../libs/shared-for-config/types/EslintRules"
 
 export const importRules = {
+  "import/consistent-type-specifier-style": [SEVERITY.ERROR, "prefer-top-level"],
   "import/extensions": extensions,
+  "import/no-cycle": [SEVERITY.ERROR, { maxDepth: 1 }],
   "import/no-default-export": SEVERITY.ERROR,
+  "import/no-deprecated": SEVERITY.WARN,
+  "import/no-empty-named-blocks": SEVERITY.ERROR,
+  "import/no-extraneous-dependencies": SEVERITY.ERROR,
+  "import/no-mutable-exports": SEVERITY.ERROR,
   "import/order": order,
   "import/prefer-default-export": SEVERITY.OFF,
 } as const satisfies EslintRules

--- a/packages/eslint-config-ts/src/flatConfig/index.ts
+++ b/packages/eslint-config-ts/src/flatConfig/index.ts
@@ -1,6 +1,7 @@
 import { airbnbBaseRecords } from "../shared/config/records/airbnbBaseRecords"
 import { customRecord } from "../shared/config/records/customRecord"
 import { eslintRecommendedRecord } from "../shared/config/records/eslintRecommendedRecord"
+import { importRecommendedRecord } from "../shared/config/records/importRecommendedRecord"
 import { initialRecord } from "../shared/config/records/initialRecord"
 import { resetRecordForStylistic } from "../shared/config/records/resetRecordForStylistic"
 import { scJsCustomRecord } from "../shared/config/records/scJsCustomRecord"
@@ -17,6 +18,7 @@ import type { EslintFlatConfig } from "../libs/shared-for-config/types/EslintFla
 
 export const flatConfig = [
   initialRecord,
+  importRecommendedRecord,
   stylisticRecord,
   eslintRecommendedRecord,
   unicornRecommendedRecords,

--- a/packages/eslint-config-ts/src/index.ts
+++ b/packages/eslint-config-ts/src/index.ts
@@ -2,6 +2,7 @@ import { flatConfig } from "./flatConfig"
 import { airbnbBaseRecords } from "./shared/config/records/airbnbBaseRecords"
 import { customRecord } from "./shared/config/records/customRecord"
 import { eslintRecommendedRecord } from "./shared/config/records/eslintRecommendedRecord"
+import { importRecommendedRecord } from "./shared/config/records/importRecommendedRecord"
 import { initialRecord } from "./shared/config/records/initialRecord"
 import { resetRecordForStylistic } from "./shared/config/records/resetRecordForStylistic"
 import { scJsCustomRecord } from "./shared/config/records/scJsCustomRecord"
@@ -27,6 +28,7 @@ const plugin = {
 
     airbnbBaseRecords,
     eslintRecommendedRecord,
+    importRecommendedRecord,
     initialRecord,
     resetRecordForStylistic,
     scJsCustomRecord,

--- a/packages/eslint-config-ts/src/shared/config/records/importRecommendedRecord/index.ts
+++ b/packages/eslint-config-ts/src/shared/config/records/importRecommendedRecord/index.ts
@@ -1,0 +1,12 @@
+import eslintConfigSCJs from "eslint-config-sc-js"
+
+import { PACKAGE_NAME } from "../../../constants/PACKAGE_NAME"
+import { settings } from "../../settings"
+
+import type { EslintFlatConfig } from "../../../../libs/shared-for-config/types/EslintFlatConfig"
+
+export const importRecommendedRecord = {
+  ...eslintConfigSCJs.configs.importRecommendedRecord,
+  name: `${PACKAGE_NAME}/importRecommendedRecord`,
+  settings,
+} as const satisfies EslintFlatConfig

--- a/yarn.lock
+++ b/yarn.lock
@@ -5162,6 +5162,7 @@ __metadata:
     cspell: "npm:^9.1.2"
     editorconfig-checker: "npm:^6.0.1"
     eslint: "npm:^9.30.0"
+    eslint-plugin-import: "npm:^2.32.0"
     fixpack: "npm:^4.0.0"
     npm-run-all2: "npm:^8.0.4"
     prettier: "npm:^3.6.2"
@@ -5173,6 +5174,7 @@ __metadata:
     "@eslint/js": ">=9.30.0"
     "@stylistic/eslint-plugin": ">=5.1.0"
     eslint-config-airbnb-base: ">=15.0.0"
+    eslint-plugin-import: ">=2.32.0"
     eslint-plugin-unicorn: ">=59.0.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## eslint-config-sc-js
- eslint-plugin-import の導入
- import 用のルールレコード更新
  - `import/consistent-type-specifier-style` to `[2, "prefer-top-level"]`
  - `import/no-cycle` to `[2, { maxDepth: 1 }]`
  - `import/no-deprecated` to `1`
  - `import/no-empty-named-blocks` to `2`
  - `import/no-extraneous-dependencies`to `2`
  - `import/no-mutable-exports` to `2`

## eslint-config-sc-ts
- eslint-config-sc-js で定義した eslint-plugin-import の利用

## eslint-config-sc-all
- eslint-config-sc-js, eslint-config-sc-ts で定義した eslint-plugin-import の利用