### PR TITLE
Add devcontainer configuration (Node 22 + pnpm)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "strict-check",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22.19.0"
+    },
+    "ghcr.io/devcontainers/features/pnpm:1": {
+      "version": "10.11.0"
+    }
+  },
+  "postCreateCommand": "pnpm install --frozen-lockfile",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "editor.formatOnSave": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Add a reproducible development container that pins Node and pnpm versions and runs dependency installation to ensure consistent local setup and editor formatting.

### Description
- Add `.devcontainer/devcontainer.json` configuring the `mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm` image and feature versions for Node (`22.19.0`) and `pnpm` (`10.11.0`).
- Set `postCreateCommand` to run `pnpm install --frozen-lockfile` so dependencies are installed reproducibly when the container is created.
- Configure VS Code customization to enable `editor.formatOnSave` for consistent formatting on save.

### Testing
- No automated tests were run for this config change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb2ffe78e08324b73ef2ec07b2f67a)