### PR TITLE
devcontainer: pnpm Feature 依存を除き postCreateCommand で pnpm@10.11.0 を有効化

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,12 +4,9 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22.19.0"
-    },
-    "ghcr.io/devcontainers/features/pnpm:1": {
-      "version": "10.11.0"
     }
   },
-  "postCreateCommand": "pnpm install --frozen-lockfile",
+  "postCreateCommand": "bash -lc 'corepack enable && corepack prepare pnpm@10.11.0 --activate && pnpm install --frozen-lockfile'",
   "customizations": {
     "vscode": {
       "settings": {


### PR DESCRIPTION
## 変更概要
- `.devcontainer/devcontainer.json` から `ghcr.io/devcontainers/features/pnpm:1` の指定を削除し、`postCreateCommand` で `corepack enable && corepack prepare pnpm@10.11.0 --activate && pnpm install --frozen-lockfile` を実行するよう変更しました。

## 背景 / 目的
- devcontainer の pnpm セットアップを feature 依存から外して、コンテナ作成時に明示的に `pnpm@10.11.0` を有効化できるようにするためです。

## 変更内容
- `features` から pnpm の指定を削除して Node feature のみを残しました。
- `postCreateCommand` を `corepack` を使って `pnpm@10.11.0` を有効化し、その後 `pnpm install --frozen-lockfile` を実行するコマンド列に変更しました。

## 影響範囲
- Devcontainer 作成時の pnpm 導入方法のみが変更され、アプリケーションの実行時挙動には影響しません。

## 動作確認
- `pnpm check-code` を実行して成功を確認しました（lint とスペルチェックが通過しました）。

## 補足
- リポジトリ運用ルールに合わせて pnpm の導入手段を固定化する変更です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccc5fcf5e88324ba1b16b54b45e1c2)