### PR TITLE
check-publish の pnpm 対応と npm 認証環境変数の追加

### DIFF
--- a/.github/actions/check-publish/action.yml
+++ b/.github/actions/check-publish/action.yml
@@ -14,7 +14,8 @@ runs:
       shell: bash
 
     - name: Can publish
-      run: npx can-npm-publish --verbose
+      run: pnpm dlx can-npm-publish --verbose
       env:
         NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
+        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
       shell: bash


### PR DESCRIPTION
## 変更概要

- GitHub Actions の composite action `check-publish` を pnpm に合わせて修正しました。

## 背景 / 目的

- yarn から pnpm に移行した環境で、CD 実行時に `npx can-npm-publish` が `ENEEDAUTH` を返して公開判定が失敗していたため、pnpm 運用下でも公開判定が安定するようにすることが目的です。

## 変更内容

- `.github/actions/check-publish/action.yml` を修正しました。
- `npx can-npm-publish --verbose` を `pnpm dlx can-npm-publish --verbose` に置き換えました。
- 環境変数に `NODE_AUTH_TOKEN: ${{ inputs.npm-token }}` を追加し、`NPM_AUTH_TOKEN` と併せて渡すようにしました。

## 影響範囲

- composite action `check-publish` を利用する CD / publish 判定ワークフローに影響します。
- `.github` 配下のみの変更で、各パッケージの実装コードには変更がありません。

## 動作確認

- `pnpm install` を実行して依存をインストールし成功しました。 (成功)
- `pnpm check-code` を実行して lint / spell-check 等が成功しました。 (成功)

## 補足

- 作業ブランチ `hotfix/cd-pnpm-auth-fix` を作成して変更を適用しています。
- 対象は GitHub Actions の構成のみであり、追加のコード修正は不要です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e361dba03c8324839731117da3cccf)