### PR TITLE
publishアクションでnpm認証を設定し、pnpm移行後の公開エラーを解消

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -10,6 +10,12 @@ runs:
     - run: corepack enable
       shell: bash
 
+    - name: Set up .npmrc
+      run: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
+      shell: bash
+
     - name: Run prepare
       run: pnpm prepare
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## 変更概要

- `.github/actions/publish/action.yml` に npm レジストリ認証設定（`~/.npmrc` 生成）を追加しました。

## 背景 / 目的

- yarn から pnpm へ移行した際に GitHub Actions の publish ジョブで npm 認証情報が適切に渡らず `pnpm publish` が失敗する問題を解消するためです。

## 変更内容

- `publish` composite action に `Set up .npmrc` ステップを追加し、`inputs.npm-token` を使って `//registry.npmjs.org/:_authToken=...` を `~/.npmrc` に書き込むようにしました。

## 影響範囲

- 影響は GitHub Actions の publish 処理（`./.github/actions/publish` を利用する CD ワークフロー）に限定されます。

## 動作確認

- `pnpm install` を実行して依存を解決しました。
- `pnpm check-code` を実行し、lint とスペルチェックなどのチェックが成功することを確認しました。

## 補足

- ご指定どおり main を起点にブランチを作成しましたが、ローカルに `main` が存在しなかったため同一コミットを基点に `main` を作成してから `fix/pnpm-publish-auth` を作成しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f344c0bf4883249e452b86391fd87a)