### PR TITLE
GitHub Actions の Node.js マトリクスを 22/24/26 に更新

### DIFF
--- a/.github/workflows/eslint-config-all@cd.yml
+++ b/.github/workflows/eslint-config-all@cd.yml
@@ -106,7 +106,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-all@ci.yml
+++ b/.github/workflows/eslint-config-all@ci.yml
@@ -100,7 +100,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-jest@cd.yml
+++ b/.github/workflows/eslint-config-jest@cd.yml
@@ -88,7 +88,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-jest@ci.yml
+++ b/.github/workflows/eslint-config-jest@ci.yml
@@ -83,7 +83,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-js@cd.yml
+++ b/.github/workflows/eslint-config-js@cd.yml
@@ -88,7 +88,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-js@ci.yml
+++ b/.github/workflows/eslint-config-js@ci.yml
@@ -83,7 +83,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-next@cd.yml
+++ b/.github/workflows/eslint-config-next@cd.yml
@@ -88,7 +88,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-next@ci.yml
+++ b/.github/workflows/eslint-config-next@ci.yml
@@ -83,7 +83,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-react@cd.yml
+++ b/.github/workflows/eslint-config-react@cd.yml
@@ -88,7 +88,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-react@ci.yml
+++ b/.github/workflows/eslint-config-react@ci.yml
@@ -83,7 +83,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-storybook@cd.yml
+++ b/.github/workflows/eslint-config-storybook@cd.yml
@@ -88,7 +88,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-storybook@ci.yml
+++ b/.github/workflows/eslint-config-storybook@ci.yml
@@ -83,7 +83,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-ts@cd.yml
+++ b/.github/workflows/eslint-config-ts@cd.yml
@@ -88,7 +88,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-config-ts@ci.yml
+++ b/.github/workflows/eslint-config-ts@ci.yml
@@ -83,7 +83,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-plugin-js@cd.yml
+++ b/.github/workflows/eslint-plugin-js@cd.yml
@@ -88,7 +88,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 
@@ -109,7 +109,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/eslint-plugin-js@ci.yml
+++ b/.github/workflows/eslint-plugin-js@ci.yml
@@ -83,7 +83,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 
@@ -103,7 +103,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## 変更概要

- GitHub Actions の `node-version` マトリクスを `20.x, 22.x, 24.x` から `22.x, 24.x, 26.x` に変更しました（`.github/workflows` 配下の 16 ファイルを更新）。

## 背景 / 目的

- CI の検証対象となる Node.js バージョンを最新方針に合わせ、古いバージョンを除外するとともに将来の互換性確認を行うためです。

## 変更内容

- `.github/workflows` 配下のワークフロー（eslint-config-*/eslint-plugin-js 系の CI/CD ファイル計16件）で `node-version` 配列を `20.x, 22.x, 24.x` から `22.x, 24.x, 26.x` に置換しました。
- 変更はコミット済みで、コミットメッセージは `chore(root): update GitHub Actions Node.js matrix to 22/24/26` としています。

## 影響範囲

- GitHub Actions の matrix ジョブで使用される Node.js バージョンに影響します。
- リポジトリ内のアプリケーション本体やパッケージのコード自体には直接の変更はありませんが、CI 上での検証対象が変わります。

## 動作確認

- `pnpm install` を実行して依存を導入し、正常に完了しました。
- `pnpm check-code` を実行して lint / spell-check / prettier 等のチェックが成功することを確認しました（`pnpm check-code` 実行済み）。

## 補足

- 依存関係やテスト構成の変更は行っていません。
- 必要であれば、追加で特定バージョン上でのテスト実行を CI 上で確認してください。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a070d1bdb488324abb66c045ad06445)