### PR TITLE
packages 配下 README の説明文を指定テキストへ統一

### DIFF
--- a/packages/eslint-config-all/README.md
+++ b/packages/eslint-config-all/README.md
@@ -1,46 +1,15 @@
-# [eslint-config-sc-all](https://strict-check-series.pages.dev/packages/eslint-config-sc-all)
+<p>
+  SC ( Strict Check ) Series is the packages for static analysis that keep maintainability on operation and development for the frontend developer.
+</p>
 
-- Strict Check config for eslint.
-- Use different config of sc series.
-    - [eslint-config-sc-js](https://www.npmjs.com/package/eslint-config-sc-js)
-    - [eslint-config-sc-ts](https://www.npmjs.com/package/eslint-config-sc-ts)
-    - [eslint-config-sc-jest](https://www.npmjs.com/package/eslint-config-sc-jest)
-    - [eslint-config-sc-react](https://www.npmjs.com/package/eslint-config-sc-react)
-    - [eslint-config-sc-next](https://www.npmjs.com/package/eslint-config-sc-next)
-    - [eslint-config-sc-storybook](https://www.npmjs.com/package/eslint-config-sc-storybook)
+<p>
+  These packages maybe able to <strong>reduce</strong> the <strong>difference notation</strong> and <strong>Confusing implementation</strong> from multiple developers.
+</p>
 
-## How to use
+<p>
+  These packages recommended to the products that need to be robust, but not recommended the teams that includes beginner, because these includes so strict and niche rule. Recommended adjust rule, when if introduce these package into the teams that includes beginner.
+</p>
 
-### Installation
-
-```shell
-$ pnpm add -D eslint-config-sc-all
-```
-
-```javascript
-// eslint.config.mjs
-import eslintConfigSCAll from "eslint-config-sc-all"
-
-export default [
-    eslintConfigSCAll.getConfigs("typescript", ["react", "next", "jest", "storybook"]),
-].flat()
-```
-
-### Arguments
-
-- First (required) - string
-    - `javascript` | `typescript`
-- Second (optional) - string array
-    - `jest`
-    - `next`
-    - `react`
-    - `storybook`
-
-### Attention
-
-- It varies the dependencies by arguments.
-
-## License
-
-- [MIT](LICENSE)
-- This includes the work that is distributed in the Apache License 2.0.
+<p style="text-align: center">
+  <a href="https://strict-check-series.pages.dev/">Documentation</a>
+</p>

--- a/packages/eslint-config-jest/README.md
+++ b/packages/eslint-config-jest/README.md
@@ -1,43 +1,15 @@
-# [eslint-config-sc-jest](https://strict-check-series.pages.dev/packages/eslint-config-sc-jest)
+<p>
+  SC ( Strict Check ) Series is the packages for static analysis that keep maintainability on operation and development for the frontend developer.
+</p>
 
-- Strict Check config for eslint.
-- For Jest.
+<p>
+  These packages maybe able to <strong>reduce</strong> the <strong>difference notation</strong> and <strong>Confusing implementation</strong> from multiple developers.
+</p>
 
-## How to use
+<p>
+  These packages recommended to the products that need to be robust, but not recommended the teams that includes beginner, because these includes so strict and niche rule. Recommended adjust rule, when if introduce these package into the teams that includes beginner.
+</p>
 
-### Installation
-
-```shell
-$ pnpm add -D eslint-config-sc-jest
-```
-
-### Use for `eslint.config.mjs`
-
-```javascript
-// eslint.config.mjs
-import eslintConfigSCJest from "eslint-config-sc-jest"
-
-export default [
-  [/* other rules for product code */],
-  eslintConfigSCJest.configs.recommended,
-].flat()
-
-// Below is equal
-export default [
-  [/* other rules for product code */],
-  eslintConfigSCJest.configs.jestPluginRecords,
-  eslintConfigSCJest.configs.customRecord,
-  eslintConfigSCJest.configs.overrideJavascriptRecord, // for javascript project
-  eslintConfigSCJest.configs.overrideTypescriptRecord, // for typecript project
-].flat()
-```
-
-## Used config, plugin ( alphabetical )
-
-### plugin
-
-- [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest)
-
-## License
-
-- [MIT](LICENSE)
+<p style="text-align: center">
+  <a href="https://strict-check-series.pages.dev/">Documentation</a>
+</p>

--- a/packages/eslint-config-js/README.md
+++ b/packages/eslint-config-js/README.md
@@ -1,60 +1,15 @@
-# [eslint-config-sc-js](https://strict-check-series.pages.dev/packages/eslint-config-sc-js)
+<p>
+  SC ( Strict Check ) Series is the packages for static analysis that keep maintainability on operation and development for the frontend developer.
+</p>
 
-- Strict Check config for eslint.
-- For Javascript.
+<p>
+  These packages maybe able to <strong>reduce</strong> the <strong>difference notation</strong> and <strong>Confusing implementation</strong> from multiple developers.
+</p>
 
-## How to use
+<p>
+  These packages recommended to the products that need to be robust, but not recommended the teams that includes beginner, because these includes so strict and niche rule. Recommended adjust rule, when if introduce these package into the teams that includes beginner.
+</p>
 
-### Installation
-
-```shell
-$ pnpm add -D eslint-config-sc-js
-```
-
-### Use for `eslint.config.mjs`
-
-```javascript
-// eslint.config.mjs
-import eslintConfigSCJs from "eslint-config-sc-js"
-
-export default [
-  eslintConfigSCJs.configs.recommended,
-].flat()
-
-// Below is equal
-export default [
-  eslintConfigSCJs.configs.initialRecord,
-  eslintConfigSCJs.configs.eslintRecommendedRecord,
-  eslintConfigSCJs.configs.unicornRecommendedRecords,
-
-  // This use eslint-config-airbnb-base
-  // For react project, this replace to eslint-config-airbnb
-  eslintConfigSCJs.configs.airbnbBaseRecords,
-
-  // This is the custom config of eslint-config-sc-js
-  eslintConfigSCJs.configs.customRecord,
-
-].flat()
-```
-
-## Used config, plugin ( alphabetical )
-
-### config
-
-- [eslint-config-airbnb-base](https://www.npmjs.com/package/eslint-config-airbnb-base)
-
-### plugin
-
-- [eslint-plugin-unicorn](https://www.npmjs.com/package/eslint-plugin-unicorn)
-
-## Recommended, but not includes
-
-### plugin
-
-- [eslint-plugin-sonarjs](https://www.npmjs.com/package/eslint-plugin-sonarjs)
-- [eslint-plugin-jsdoc](https://www.npmjs.com/package/eslint-plugin-jsdoc)
-
-## License
-
-- [MIT](LICENSE)
-- This includes the work that is distributed in the Apache License 2.0.
+<p style="text-align: center">
+  <a href="https://strict-check-series.pages.dev/">Documentation</a>
+</p>

--- a/packages/eslint-config-next/README.md
+++ b/packages/eslint-config-next/README.md
@@ -1,80 +1,15 @@
-# [eslint-config-sc-next](https://strict-check-series.pages.dev/packages/eslint-config-sc-next)
+<p>
+  SC ( Strict Check ) Series is the packages for static analysis that keep maintainability on operation and development for the frontend developer.
+</p>
 
-- Strict Check config for eslint.
-- For NextJS.
+<p>
+  These packages maybe able to <strong>reduce</strong> the <strong>difference notation</strong> and <strong>Confusing implementation</strong> from multiple developers.
+</p>
 
-## How to use
+<p>
+  These packages recommended to the products that need to be robust, but not recommended the teams that includes beginner, because these includes so strict and niche rule. Recommended adjust rule, when if introduce these package into the teams that includes beginner.
+</p>
 
-### Installation
-
-```shell
-$ pnpm add -D eslint-config-sc-next
-```
-
-### Use for `eslint.config.mjs`
-
-#### For Javascript
-
-```javascript
-// eslint.config.mjs
-import eslintConfigSCNext from "eslint-config-sc-next"
-
-export default [
-  eslintConfigSCNext.configs.recommended,
-].flat()
-
-// Below is equal
-export default [
-  eslintConfigSCNext.configs.initialRecord,
-  eslintConfigSCNext.configs.eslintRecommendedRecord,
-  eslintConfigSCNext.configs.unicornRecommendedRecords,
-  eslintConfigSCNext.configs.reactRecords,
-  eslintConfigSCNext.configs.nextRecords,
-  eslintConfigSCNext.configs.airbnbRecords,
-
-  // This is the custom config of eslint-config-sc-js / eslint-config-sc-next
-  eslintConfigSCNext.configs.scJsCustomRecord,
-  eslintConfigSCNext.configs.scRectCustomRecord,
-
-].flat()
-```
-
-#### For Typescript
-
-```javascript
-import eslintConfigSCTs from "eslint-config-sc-ts"
-import eslintConfigSCNext from "eslint-config-sc-next"
-
-export default [
-    eslintConfigSCNext.configs.initialRecord,
-    eslintConfigSCNext.configs.eslintRecommendedRecord,
-    eslintConfigSCTs.configs.typescriptEslintStrictTypeCheckedRecords,
-    eslintConfigSCNext.configs.unicornRecommendedRecords,
-    eslintConfigSCNext.configs.reactRecords,
-    eslintConfigSCNext.configs.nextRecords,
-    eslintConfigSCNext.configs.airbnbRecords,
-
-    eslintConfigSCNext.configs.scJsCustomRecord,
-    eslintConfigSCTs.configs.customRecords,
-    eslintConfigSCNext.configs.customRecord,
-    eslintConfigSCNext.configs.customRecordWithTypescript,
-].flat()
-```
-
-## Used config, plugin ( alphabetical )
-
-### config
-
-- [eslint-config-sc-react](https://www.npmjs.com/package/eslint-config-sc-react)
-
-## Recommended, but not includes
-
-### plugin
-
-- [eslint-plugin-sonarjs](https://www.npmjs.com/package/eslint-plugin-sonarjs)
-- [eslint-plugin-jsdoc](https://www.npmjs.com/package/eslint-plugin-jsdoc)
-
-## License
-
-- [MIT](LICENSE)
-- This includes the work that is distributed in the Apache License 2.0.
+<p style="text-align: center">
+  <a href="https://strict-check-series.pages.dev/">Documentation</a>
+</p>

--- a/packages/eslint-config-react/README.md
+++ b/packages/eslint-config-react/README.md
@@ -1,79 +1,15 @@
-# [eslint-config-sc-react](https://strict-check-series.pages.dev/packages/eslint-config-sc-react)
+<p>
+  SC ( Strict Check ) Series is the packages for static analysis that keep maintainability on operation and development for the frontend developer.
+</p>
 
-- Strict Check config for eslint.
-- For ReactJS.
+<p>
+  These packages maybe able to <strong>reduce</strong> the <strong>difference notation</strong> and <strong>Confusing implementation</strong> from multiple developers.
+</p>
 
-## How to use
+<p>
+  These packages recommended to the products that need to be robust, but not recommended the teams that includes beginner, because these includes so strict and niche rule. Recommended adjust rule, when if introduce these package into the teams that includes beginner.
+</p>
 
-### Installation
-
-```shell
-$ pnpm add -D eslint-config-sc-react
-```
-
-### Use for `eslint.config.mjs`
-
-#### For Javascript
-
-```javascript
-// eslint.config.mjs
-import eslintConfigSCReact from "eslint-config-sc-react"
-
-export default [
-  ...eslintConfigSCReact.configs.recommended,
-]
-
-// Below is equal
-export default [
-  eslintConfigSCReact.configs.initialRecord,
-  eslintConfigSCReact.configs.eslintRecommendedRecord,
-  eslintConfigSCReact.configs.unicornRecommendedRecords,
-  eslintConfigSCReact.configs.reactRecords,
-  eslintConfigSCReact.configs.airbnbRecords,
-
-  // This is the custom config of eslint-config-sc-js / eslint-config-sc-react
-  eslintConfigSCReact.configs.scJsCustomRecord,
-  eslintConfigSCReact.configs.customRecord,
-
-].flat()
-```
-
-#### For Typescript
-
-```javascript
-import eslintConfigSCTs from "eslint-config-sc-ts"
-import eslintConfigSCReact from "eslint-config-sc-react"
-
-export default [
-    eslintConfigSCReact.configs.initialRecord,
-    eslintConfigSCReact.configs.eslintRecommendedRecord,
-    eslintConfigSCReact.configs.unicornRecommendedRecords,
-    eslintConfigSCTs.configs.typescriptEslintStrictTypeCheckedRecords,
-    eslintConfigSCReact.configs.reactRecords,
-    eslintConfigSCReact.configs.airbnbRecords,
-
-    // This is the custom config of eslint-config-sc-js / eslint-config-sc-react
-    eslintConfigSCReact.configs.scJsCustomRecord,
-    eslintConfigSCReact.configs.customRecord,
-    eslintConfigSCReact.configs.customRecordWithTypescript,
-].flat()
-```
-
-## Used config, plugin ( alphabetical )
-
-### config
-
-- [eslint-config-airbnb](https://www.npmjs.com/package/eslint-config-airbnb)
-- [eslint-config-sc-js](https://www.npmjs.com/package/eslint-config-sc-js)
-
-## Recommended, but not includes
-
-### plugin
-
-- [eslint-plugin-sonarjs](https://www.npmjs.com/package/eslint-plugin-sonarjs)
-- [eslint-plugin-jsdoc](https://www.npmjs.com/package/eslint-plugin-jsdoc)
-
-## License
-
-- [MIT](LICENSE)
-- This includes the work that is distributed in the Apache License 2.0.
+<p style="text-align: center">
+  <a href="https://strict-check-series.pages.dev/">Documentation</a>
+</p>

--- a/packages/eslint-config-storybook/README.md
+++ b/packages/eslint-config-storybook/README.md
@@ -1,42 +1,15 @@
-# [eslint-config-sc-storybook](https://strict-check-series.pages.dev/packages/eslint-config-sc-storybook)
+<p>
+  SC ( Strict Check ) Series is the packages for static analysis that keep maintainability on operation and development for the frontend developer.
+</p>
 
-- Strict Check config for eslint.
-- For Storybook.
+<p>
+  These packages maybe able to <strong>reduce</strong> the <strong>difference notation</strong> and <strong>Confusing implementation</strong> from multiple developers.
+</p>
 
-## How to use
+<p>
+  These packages recommended to the products that need to be robust, but not recommended the teams that includes beginner, because these includes so strict and niche rule. Recommended adjust rule, when if introduce these package into the teams that includes beginner.
+</p>
 
-### Installation
-
-```shell
-$ pnpm add -D eslint-config-sc-storybook
-```
-
-### Use for `eslint.config.mjs`
-
-```javascript
-// eslint.config.mjs
-import eslintConfigSCStorybook from "eslint-config-sc-storybook"
-
-export default [
-  [/* other rules for product code */],
-  eslintConfigSCStorybook.configs.recommended,
-].flat()
-
-// Below is equal
-export default [
-  [/* other rules for product code */],
-  eslintConfigSCStorybook.configs.storybookConfigRecords,
-  eslintConfigSCStorybook.configs.overrideJavascriptRecord, // for javascript project
-  eslintConfigSCStorybook.configs.overrideTypescriptRecord, // for typecript project
-].flat()
-```
-
-## Used config, plugin ( alphabetical )
-
-### plugin
-
-- [eslint-plugin-storybook](https://www.npmjs.com/package/eslint-plugin-storybook)
-
-## License
-
-- [MIT](LICENSE)
+<p style="text-align: center">
+  <a href="https://strict-check-series.pages.dev/">Documentation</a>
+</p>

--- a/packages/eslint-config-ts/README.md
+++ b/packages/eslint-config-ts/README.md
@@ -1,76 +1,15 @@
-# [eslint-config-sc-ts](https://strict-check-series.pages.dev/packages/eslint-config-sc-ts)
+<p>
+  SC ( Strict Check ) Series is the packages for static analysis that keep maintainability on operation and development for the frontend developer.
+</p>
 
-- Strict Check config for eslint.
-- For Typescript.
+<p>
+  These packages maybe able to <strong>reduce</strong> the <strong>difference notation</strong> and <strong>Confusing implementation</strong> from multiple developers.
+</p>
 
-## How to use
+<p>
+  These packages recommended to the products that need to be robust, but not recommended the teams that includes beginner, because these includes so strict and niche rule. Recommended adjust rule, when if introduce these package into the teams that includes beginner.
+</p>
 
-### Installation
-
-```shell
-$ pnpm add -D eslint-config-sc-ts
-```
-
-### Use for `eslint.config.mjs`
-
-```javascript
-// eslint.config.mjs
-import eslintConfigSCTs from "eslint-config-sc-ts"
-
-export default [
-  eslintConfigSCTs.configs.recommended,
-  {
-    languageOptions: {
-      parserOptions: {
-        project: "/path/to/tsconfig.json", // default, refer <root>/tsoncifg.json
-      },
-    },
-  },
-].flat()
-
-// Below is equal
-export default [
-  eslintConfigSCTs.configs.initialRecord,
-  eslintConfigSCTs.configs.eslintRecommendedRecord,
-  eslintConfigSCTs.configs.unicornRecommendedRecords,
-  eslintConfigSCTs.configs.typescriptEslintStrictTypeCheckedRecords,
-
-  // This use eslint-config-airbnb-base
-  // For react project, this replace to eslint-config-airbnb
-  eslintConfigSCTs.configs.airbnbBaseRecords,
-
-  // This is the custom config of eslint-config-sc-js / eslint-config-sc-ts
-  eslintConfigSCTs.configs.scJsCustomRecord,
-  eslintConfigSCTs.configs.customRecord,
-
-  {
-    languageOptions: {
-      parserOptions: {
-        project: "/path/to/tsconfig.json", // default, refer <root>/tsoncifg.json
-      },
-    },
-  },
-].flat()
-```
-
-## Used config, plugin ( alphabetical )
-
-### config
-
-- [eslint-config-sc-js](https://www.npmjs.com/package/eslint-config-sc-js)
-
-### plugin
-
-- [typescript-eslint](https://www.npmjs.com/package/typescript-eslint)
-
-## Recommended, but not includes
-
-### plugin
-
-- [eslint-plugin-sonarjs](https://www.npmjs.com/package/eslint-plugin-sonarjs)
-- [eslint-plugin-jsdoc](https://www.npmjs.com/package/eslint-plugin-jsdoc)
-
-## License
-
-- [MIT](LICENSE)
-- This includes the work that is distributed in the Apache License 2.0.
+<p style="text-align: center">
+  <a href="https://strict-check-series.pages.dev/">Documentation</a>
+</p>

--- a/packages/eslint-plugin-js/README.md
+++ b/packages/eslint-plugin-js/README.md
@@ -1,49 +1,15 @@
-# [eslint-plugin-sc-js](https://strict-check-series.pages.dev/packages/eslint-plugin-sc-js)
+<p>
+  SC ( Strict Check ) Series is the packages for static analysis that keep maintainability on operation and development for the frontend developer.
+</p>
 
-- Strict Check rules for eslint.
--   - For Javascript / Typescript.
+<p>
+  These packages maybe able to <strong>reduce</strong> the <strong>difference notation</strong> and <strong>Confusing implementation</strong> from multiple developers.
+</p>
 
-**Supports eslint v9.**
+<p>
+  These packages recommended to the products that need to be robust, but not recommended the teams that includes beginner, because these includes so strict and niche rule. Recommended adjust rule, when if introduce these package into the teams that includes beginner.
+</p>
 
-## Installation
-
-```shell
-# by pnpm
-$ pnpm add -D eslint-plugin-sc-js
-
-# by npm
-$ npm i --save-dev eslint-plugin-sc-js
-```
-
-## Usage
-
-### for `eslint.config.mjs`
-
-```js
-import eslintPluginSCJs from "eslint-plugin-sc-js"
-
-export default [
-    {
-        plugins: {
-            js: eslintPluginSCJs, // It is not necessary when use the recommended config
-        },
-    },
-    eslintPluginSCJs.configs.recommended,
-]
-```
-
-## Rules
-
-✅: Set in the recommended configuration.
-
-| Name                                                                               | Description                                      | 💼  |
-| ---------------------------------------------------------------------------------- | ------------------------------------------------ | --- |
-| [file-path-patterns](docs/rules/file-path-patterns.md)                             | Check if file path follows regular expression    |     |
-| [forbidden-multiple-named-exports](docs/rules/forbidden-multiple-named-exports.md) | Forbidden the multiple named exports at one file |     |
-| [individual-import](docs/rules/individual-import.md)                               | Import them individual                           |     |
-| [match-names-of-file-and-export](docs/rules/match-names-of-file-and-export.md)     | Match name of filename and export target         |     |
-| [restrict-use-of-process-env](docs/rules/restrict-use-of-process-env.md)           | Restrict environment usage                       | ✅  |
-
-## License
-
-- [MIT](LICENSE)
+<p style="text-align: center">
+  <a href="https://strict-check-series.pages.dev/">Documentation</a>
+</p>


### PR DESCRIPTION
## 変更概要

- `packages/*/README.md`（8ファイル）の本文を、指定された HTML 段落構成の文章へ統一しました。

## 背景 / 目的

- パッケージごとにばらついていた簡易説明を共通の案内文に揃え、シリーズ全体で一貫したドキュメント表示を提供するためです。

## 変更内容

- 以下 8 ファイルの README を全面差し替えしました。`
  - `packages/eslint-config-all/README.md`
  - `packages/eslint-config-jest/README.md`
  - `packages/eslint-config-js/README.md`
  - `packages/eslint-config-next/README.md`
  - `packages/eslint-config-react/README.md`
  - `packages/eslint-config-storybook/README.md`
  - `packages/eslint-config-ts/README.md`
  - `packages/eslint-plugin-js/README.md`
- 変更はドキュメント（README）の内容のみで、実装や依存関係には影響ありません。

## 影響範囲

- README 表記のみの変更であり、ビルドやライブラリの挙動には影響しません。

## 動作確認

- 依存が未インストールのため、初回の `pnpm check-code` は `run-p: not found` により失敗しましたが、`pnpm install` 実行後に再度 `pnpm check-code` を実行し、チェックが成功することを確認しました。
- コミットは Semantic Commit Message に準拠する形式で作成しています（`docs(packages): update all package readme descriptions`）。

## 補足

- ドキュメントの差し替えは一括で行っているため、将来的に各パッケージ固有の詳細説明が必要な場合は個別に追記してください。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0715a332c48324a6ba68782c81403c)