### PR TITLE
feat(eslint-config-react,eslint-config-js,eslint-config-ts,eslint-config-all): eslint エコシステムの抜けを埋める

### DIFF
--- a/dry-run/dr-eslint-config-sc-all/sample/js-next-jest-storybook/src/index.jsx
+++ b/dry-run/dr-eslint-config-sc-all/sample/js-next-jest-storybook/src/index.jsx
@@ -85,7 +85,7 @@ export const ReactTest4 = () => (
 
 export const ReactTest5 = () => (
   <div>
-    {/* eslint-disable-next-line no-magic-numbers */}
+    {/* eslint-disable-next-line no-magic-numbers, react-hooks/purity */}
     {(Math.random() * 10) % 2 ? (
       // eslint-disable-next-line react/jsx-indent
         <div>1</div>

--- a/dry-run/dr-eslint-config-sc-all/sample/ts-next-jest-storybook/src/index.tsx
+++ b/dry-run/dr-eslint-config-sc-all/sample/ts-next-jest-storybook/src/index.tsx
@@ -109,7 +109,7 @@ export const ReactTest4 = () => <ReactTest3 {...reactTest3Props} />
 
 export const ReactTest5 = () => (
   <div>
-    {/* eslint-disable-next-line @typescript-eslint/no-magic-numbers */}
+    {/* eslint-disable-next-line @typescript-eslint/no-magic-numbers, react-hooks/purity */}
     {(Math.random() * 10) % 2 ? (
       // eslint-disable-next-line react/jsx-indent
         <div>1</div>

--- a/packages/eslint-config-all/spec/tests/getConfigs/modules/getConfigsBase/index.test.ts
+++ b/packages/eslint-config-all/spec/tests/getConfigs/modules/getConfigsBase/index.test.ts
@@ -4,16 +4,17 @@ import { getConfigsBase } from "../../../../../src/getConfigs/modules/getConfigs
 describe("getConfigsBase", () => {
   describe("javascript", () => {
     const result = getConfigsBase("javascript")
-    it("getConfigsBase の戻り値は配列長6", () => {
-      expect(result).toHaveLength(6)
+    it("getConfigsBase の戻り値は配列長7", () => {
+      expect(result).toHaveLength(7)
     })
     it.each([
       [0, "eslint-config-sc-js/initialRecord"],
       [1, "eslint-config-sc-js/importRecommendedRecord"],
-      [2, "eslint-config-sc-js/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-js/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-js/airbnbBaseRecords"],
-      [5, "eslint-config-sc-js/customRecord"],
+      [2, "eslint-config-sc-js/promiseRecommendedRecord"],
+      [3, "eslint-config-sc-js/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-js/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-js/airbnbBaseRecords"],
+      [6, "eslint-config-sc-js/customRecord"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
@@ -21,21 +22,22 @@ describe("getConfigsBase", () => {
 
   describe("javascript with jest, storybook", () => {
     const result = getConfigsBase("javascript", ["jest", "storybook"])
-    it("getConfigsBase の戻り値は配列長11", () => {
-      expect(result).toHaveLength(11)
+    it("getConfigsBase の戻り値は配列長12", () => {
+      expect(result).toHaveLength(12)
     })
     it.each([
       [0, "eslint-config-sc-js/initialRecord"],
       [1, "eslint-config-sc-js/importRecommendedRecord"],
-      [2, "eslint-config-sc-js/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-js/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-js/airbnbBaseRecords"],
-      [5, "eslint-config-sc-js/customRecord"],
-      [6, "eslint-config-sc-storybook/storybookConfigRecords"],
-      [7, "eslint-config-sc-storybook/overrideJavascriptRecord"],
-      [8, "eslint-config-sc-jest/jestPluginRecords"],
-      [9, "eslint-config-sc-jest/customRecord"],
-      [10, "eslint-config-sc-jest/overrideJavascriptRecord"],
+      [2, "eslint-config-sc-js/promiseRecommendedRecord"],
+      [3, "eslint-config-sc-js/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-js/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-js/airbnbBaseRecords"],
+      [6, "eslint-config-sc-js/customRecord"],
+      [7, "eslint-config-sc-storybook/storybookConfigRecords"],
+      [8, "eslint-config-sc-storybook/overrideJavascriptRecord"],
+      [9, "eslint-config-sc-jest/jestPluginRecords"],
+      [10, "eslint-config-sc-jest/customRecord"],
+      [11, "eslint-config-sc-jest/overrideJavascriptRecord"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
@@ -43,18 +45,19 @@ describe("getConfigsBase", () => {
 
   describe("typescript", () => {
     const result = getConfigsBase("typescript")
-    it("getConfigsBase の戻り値は配列長8", () => {
-      expect(result).toHaveLength(8)
+    it("getConfigsBase の戻り値は配列長9", () => {
+      expect(result).toHaveLength(9)
     })
     it.each([
       [0, "eslint-config-sc-ts/initialRecord"],
       [1, "eslint-config-sc-ts/importRecommendedRecord"],
-      [2, "eslint-config-sc-ts/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-ts/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
-      [5, "eslint-config-sc-ts/airbnbBaseRecords"],
-      [6, "eslint-config-sc-ts/scJsCustomRecord"],
-      [7, "eslint-config-sc-ts/customRecord"],
+      [2, "eslint-config-sc-ts/promiseRecommendedRecord"],
+      [3, "eslint-config-sc-ts/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-ts/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
+      [6, "eslint-config-sc-ts/airbnbBaseRecords"],
+      [7, "eslint-config-sc-ts/scJsCustomRecord"],
+      [8, "eslint-config-sc-ts/customRecord"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
@@ -62,23 +65,24 @@ describe("getConfigsBase", () => {
 
   describe("typescript with jest, storybook", () => {
     const result = getConfigsBase("typescript", ["jest", "storybook"])
-    it("getConfigsBase の戻り値は配列長13", () => {
-      expect(result).toHaveLength(13)
+    it("getConfigsBase の戻り値は配列長14", () => {
+      expect(result).toHaveLength(14)
     })
     it.each([
       [0, "eslint-config-sc-ts/initialRecord"],
       [1, "eslint-config-sc-ts/importRecommendedRecord"],
-      [2, "eslint-config-sc-ts/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-ts/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
-      [5, "eslint-config-sc-ts/airbnbBaseRecords"],
-      [6, "eslint-config-sc-ts/scJsCustomRecord"],
-      [7, "eslint-config-sc-ts/customRecord"],
-      [8, "eslint-config-sc-storybook/storybookConfigRecords"],
-      [9, "eslint-config-sc-storybook/overrideTypescriptRecord"],
-      [10, "eslint-config-sc-jest/jestPluginRecords"],
-      [11, "eslint-config-sc-jest/customRecord"],
-      [12, "eslint-config-sc-jest/overrideTypescriptRecord"],
+      [2, "eslint-config-sc-ts/promiseRecommendedRecord"],
+      [3, "eslint-config-sc-ts/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-ts/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
+      [6, "eslint-config-sc-ts/airbnbBaseRecords"],
+      [7, "eslint-config-sc-ts/scJsCustomRecord"],
+      [8, "eslint-config-sc-ts/customRecord"],
+      [9, "eslint-config-sc-storybook/storybookConfigRecords"],
+      [10, "eslint-config-sc-storybook/overrideTypescriptRecord"],
+      [11, "eslint-config-sc-jest/jestPluginRecords"],
+      [12, "eslint-config-sc-jest/customRecord"],
+      [13, "eslint-config-sc-jest/overrideTypescriptRecord"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })

--- a/packages/eslint-config-all/spec/tests/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForJavascript/index.test.ts
+++ b/packages/eslint-config-all/spec/tests/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForJavascript/index.test.ts
@@ -4,20 +4,21 @@ import { getConfigName } from "../getConfigName"
 describe("getConfigsBaseForJavascript", () => {
   describe("javascript with react", () => {
     const result = getConfigsBaseForJavascript(["react"])
-    it("getConfigsBaseForJavascript の戻り値は配列長10", () => {
-      expect(result).toHaveLength(10)
+    it("getConfigsBaseForJavascript の戻り値は配列長11", () => {
+      expect(result).toHaveLength(11)
     })
     it.each([
       [0, "eslint-config-sc-js/initialRecord"],
       [1, "eslint-config-sc-js/importRecommendedRecord"],
-      [2, "eslint-config-sc-js/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-js/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-react/initialRecord"],
-      [5, "eslint-config-sc-react/airbnbRecords"],
-      [6, "eslint-config-sc-react/reactRecords"],
-      [7, "eslint-config-sc-react/scJsCustomRecord"],
-      [8, "eslint-config-sc-js/customRecord"],
-      [9, "eslint-config-sc-react/customRecord"],
+      [2, "eslint-config-sc-js/promiseRecommendedRecord"],
+      [3, "eslint-config-sc-js/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-js/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-react/initialRecord"],
+      [6, "eslint-config-sc-react/airbnbRecords"],
+      [7, "eslint-config-sc-react/reactRecords"],
+      [8, "eslint-config-sc-react/scJsCustomRecord"],
+      [9, "eslint-config-sc-js/customRecord"],
+      [10, "eslint-config-sc-react/customRecord"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
@@ -25,21 +26,22 @@ describe("getConfigsBaseForJavascript", () => {
 
   describe("javascript with react, next", () => {
     const result = getConfigsBaseForJavascript(["next", "react"])
-    it("getConfigsBaseForJavascript の戻り値は配列長11", () => {
-      expect(result).toHaveLength(11)
+    it("getConfigsBaseForJavascript の戻り値は配列長12", () => {
+      expect(result).toHaveLength(12)
     })
     it.each([
       [0, "eslint-config-sc-js/initialRecord"],
       [1, "eslint-config-sc-js/importRecommendedRecord"],
-      [2, "eslint-config-sc-js/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-js/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-next/nextRecord"],
-      [5, "eslint-config-sc-react/initialRecord"],
-      [6, "eslint-config-sc-react/airbnbRecords"],
-      [7, "eslint-config-sc-react/reactRecords"],
-      [8, "eslint-config-sc-react/scJsCustomRecord"],
-      [9, "eslint-config-sc-js/customRecord"],
-      [10, "eslint-config-sc-react/customRecord"],
+      [2, "eslint-config-sc-js/promiseRecommendedRecord"],
+      [3, "eslint-config-sc-js/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-js/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-next/nextRecord"],
+      [6, "eslint-config-sc-react/initialRecord"],
+      [7, "eslint-config-sc-react/airbnbRecords"],
+      [8, "eslint-config-sc-react/reactRecords"],
+      [9, "eslint-config-sc-react/scJsCustomRecord"],
+      [10, "eslint-config-sc-js/customRecord"],
+      [11, "eslint-config-sc-react/customRecord"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
@@ -47,23 +49,24 @@ describe("getConfigsBaseForJavascript", () => {
 
   describe("javascript with react, next, storybook", () => {
     const result = getConfigsBaseForJavascript(["next", "react", "storybook"])
-    it("getConfigsBaseForJavascript の戻り値は配列長13", () => {
-      expect(result).toHaveLength(13)
+    it("getConfigsBaseForJavascript の戻り値は配列長14", () => {
+      expect(result).toHaveLength(14)
     })
     it.each([
       [0, "eslint-config-sc-js/initialRecord"],
       [1, "eslint-config-sc-js/importRecommendedRecord"],
-      [2, "eslint-config-sc-js/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-js/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-next/nextRecord"],
-      [5, "eslint-config-sc-react/initialRecord"],
-      [6, "eslint-config-sc-react/airbnbRecords"],
-      [7, "eslint-config-sc-react/reactRecords"],
-      [8, "eslint-config-sc-react/scJsCustomRecord"],
-      [9, "eslint-config-sc-js/customRecord"],
-      [10, "eslint-config-sc-react/customRecord"],
-      [11, "eslint-config-sc-storybook/storybookConfigRecords"],
-      [12, "eslint-config-sc-storybook/overrideJavascriptRecord"],
+      [2, "eslint-config-sc-js/promiseRecommendedRecord"],
+      [3, "eslint-config-sc-js/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-js/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-next/nextRecord"],
+      [6, "eslint-config-sc-react/initialRecord"],
+      [7, "eslint-config-sc-react/airbnbRecords"],
+      [8, "eslint-config-sc-react/reactRecords"],
+      [9, "eslint-config-sc-react/scJsCustomRecord"],
+      [10, "eslint-config-sc-js/customRecord"],
+      [11, "eslint-config-sc-react/customRecord"],
+      [12, "eslint-config-sc-storybook/storybookConfigRecords"],
+      [13, "eslint-config-sc-storybook/overrideJavascriptRecord"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
@@ -71,26 +74,27 @@ describe("getConfigsBaseForJavascript", () => {
 
   describe("javascript with react, next, storybook, jest", () => {
     const result = getConfigsBaseForJavascript(["next", "react", "storybook", "jest"])
-    it("getConfigsBaseForJavascript の戻り値は配列長16", () => {
-      expect(result).toHaveLength(16)
+    it("getConfigsBaseForJavascript の戻り値は配列長17", () => {
+      expect(result).toHaveLength(17)
     })
     it.each([
       [0, "eslint-config-sc-js/initialRecord"],
       [1, "eslint-config-sc-js/importRecommendedRecord"],
-      [2, "eslint-config-sc-js/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-js/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-next/nextRecord"],
-      [5, "eslint-config-sc-react/initialRecord"],
-      [6, "eslint-config-sc-react/airbnbRecords"],
-      [7, "eslint-config-sc-react/reactRecords"],
-      [8, "eslint-config-sc-react/scJsCustomRecord"],
-      [9, "eslint-config-sc-js/customRecord"],
-      [10, "eslint-config-sc-react/customRecord"],
-      [11, "eslint-config-sc-storybook/storybookConfigRecords"],
-      [12, "eslint-config-sc-storybook/overrideJavascriptRecord"],
-      [13, "eslint-config-sc-jest/jestPluginRecords"],
-      [14, "eslint-config-sc-jest/customRecord"],
-      [15, "eslint-config-sc-jest/overrideJavascriptRecord"],
+      [2, "eslint-config-sc-js/promiseRecommendedRecord"],
+      [3, "eslint-config-sc-js/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-js/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-next/nextRecord"],
+      [6, "eslint-config-sc-react/initialRecord"],
+      [7, "eslint-config-sc-react/airbnbRecords"],
+      [8, "eslint-config-sc-react/reactRecords"],
+      [9, "eslint-config-sc-react/scJsCustomRecord"],
+      [10, "eslint-config-sc-js/customRecord"],
+      [11, "eslint-config-sc-react/customRecord"],
+      [12, "eslint-config-sc-storybook/storybookConfigRecords"],
+      [13, "eslint-config-sc-storybook/overrideJavascriptRecord"],
+      [14, "eslint-config-sc-jest/jestPluginRecords"],
+      [15, "eslint-config-sc-jest/customRecord"],
+      [16, "eslint-config-sc-jest/overrideJavascriptRecord"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })

--- a/packages/eslint-config-all/spec/tests/getConfigs/modules/getConfigsBase/modules/getConfigsBaseTypescript/index.test.ts
+++ b/packages/eslint-config-all/spec/tests/getConfigs/modules/getConfigsBase/modules/getConfigsBaseTypescript/index.test.ts
@@ -4,23 +4,24 @@ import { getConfigName } from "../getConfigName"
 describe("getConfigsBaseForTypescript", () => {
   describe("typescript with react", () => {
     const result = getConfigsBaseForTypescript(["react"])
-    it("getConfigsBaseForTypescript の戻り値は配列長13", () => {
-      expect(result).toHaveLength(13)
+    it("getConfigsBaseForTypescript の戻り値は配列長14", () => {
+      expect(result).toHaveLength(14)
     })
     it.each([
       [0, "eslint-config-sc-ts/initialRecord"],
       [1, "eslint-config-sc-ts/importRecommendedRecord"],
-      [2, "eslint-config-sc-ts/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-ts/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
-      [5, "eslint-config-sc-react/initialRecord"],
-      [6, "eslint-config-sc-react/airbnbRecords"],
-      [7, "eslint-config-sc-react/reactRecords"],
-      [8, "eslint-config-sc-react/scJsCustomRecord"],
-      [9, "eslint-config-sc-ts/scJsCustomRecord"],
-      [10, "eslint-config-sc-ts/customRecord"],
-      [11, "eslint-config-sc-react/customRecord"],
-      [12, "eslint-config-sc-react/customRecordWithTypescript"],
+      [2, "eslint-config-sc-ts/promiseRecommendedRecord"],
+      [3, "eslint-config-sc-ts/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-ts/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
+      [6, "eslint-config-sc-react/initialRecord"],
+      [7, "eslint-config-sc-react/airbnbRecords"],
+      [8, "eslint-config-sc-react/reactRecords"],
+      [9, "eslint-config-sc-react/scJsCustomRecord"],
+      [10, "eslint-config-sc-ts/scJsCustomRecord"],
+      [11, "eslint-config-sc-ts/customRecord"],
+      [12, "eslint-config-sc-react/customRecord"],
+      [13, "eslint-config-sc-react/customRecordWithTypescript"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
@@ -28,24 +29,25 @@ describe("getConfigsBaseForTypescript", () => {
 
   describe("typescript with react, next", () => {
     const result = getConfigsBaseForTypescript(["next", "react"])
-    it("getConfigsBaseForTypescript の戻り値は配列長14", () => {
-      expect(result).toHaveLength(14)
+    it("getConfigsBaseForTypescript の戻り値は配列長15", () => {
+      expect(result).toHaveLength(15)
     })
     it.each([
       [0, "eslint-config-sc-ts/initialRecord"],
       [1, "eslint-config-sc-ts/importRecommendedRecord"],
-      [2, "eslint-config-sc-ts/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-ts/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
-      [5, "eslint-config-sc-next/nextRecord"],
-      [6, "eslint-config-sc-react/initialRecord"],
-      [7, "eslint-config-sc-react/airbnbRecords"],
-      [8, "eslint-config-sc-react/reactRecords"],
-      [9, "eslint-config-sc-react/scJsCustomRecord"],
-      [10, "eslint-config-sc-ts/scJsCustomRecord"],
-      [11, "eslint-config-sc-ts/customRecord"],
-      [12, "eslint-config-sc-react/customRecord"],
-      [13, "eslint-config-sc-react/customRecordWithTypescript"],
+      [2, "eslint-config-sc-ts/promiseRecommendedRecord"],
+      [3, "eslint-config-sc-ts/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-ts/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
+      [6, "eslint-config-sc-next/nextRecord"],
+      [7, "eslint-config-sc-react/initialRecord"],
+      [8, "eslint-config-sc-react/airbnbRecords"],
+      [9, "eslint-config-sc-react/reactRecords"],
+      [10, "eslint-config-sc-react/scJsCustomRecord"],
+      [11, "eslint-config-sc-ts/scJsCustomRecord"],
+      [12, "eslint-config-sc-ts/customRecord"],
+      [13, "eslint-config-sc-react/customRecord"],
+      [14, "eslint-config-sc-react/customRecordWithTypescript"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
@@ -53,26 +55,27 @@ describe("getConfigsBaseForTypescript", () => {
 
   describe("typescript with react, next, storybook", () => {
     const result = getConfigsBaseForTypescript(["next", "react", "storybook"])
-    it("getConfigsBaseForTypescript の戻り値は配列長16", () => {
-      expect(result).toHaveLength(16)
+    it("getConfigsBaseForTypescript の戻り値は配列長17", () => {
+      expect(result).toHaveLength(17)
     })
     it.each([
       [0, "eslint-config-sc-ts/initialRecord"],
       [1, "eslint-config-sc-ts/importRecommendedRecord"],
-      [2, "eslint-config-sc-ts/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-ts/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
-      [5, "eslint-config-sc-next/nextRecord"],
-      [6, "eslint-config-sc-react/initialRecord"],
-      [7, "eslint-config-sc-react/airbnbRecords"],
-      [8, "eslint-config-sc-react/reactRecords"],
-      [9, "eslint-config-sc-react/scJsCustomRecord"],
-      [10, "eslint-config-sc-ts/scJsCustomRecord"],
-      [11, "eslint-config-sc-ts/customRecord"],
-      [12, "eslint-config-sc-react/customRecord"],
-      [13, "eslint-config-sc-react/customRecordWithTypescript"],
-      [14, "eslint-config-sc-storybook/storybookConfigRecords"],
-      [15, "eslint-config-sc-storybook/overrideTypescriptRecord"],
+      [2, "eslint-config-sc-ts/promiseRecommendedRecord"],
+      [3, "eslint-config-sc-ts/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-ts/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
+      [6, "eslint-config-sc-next/nextRecord"],
+      [7, "eslint-config-sc-react/initialRecord"],
+      [8, "eslint-config-sc-react/airbnbRecords"],
+      [9, "eslint-config-sc-react/reactRecords"],
+      [10, "eslint-config-sc-react/scJsCustomRecord"],
+      [11, "eslint-config-sc-ts/scJsCustomRecord"],
+      [12, "eslint-config-sc-ts/customRecord"],
+      [13, "eslint-config-sc-react/customRecord"],
+      [14, "eslint-config-sc-react/customRecordWithTypescript"],
+      [15, "eslint-config-sc-storybook/storybookConfigRecords"],
+      [16, "eslint-config-sc-storybook/overrideTypescriptRecord"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })
@@ -80,29 +83,30 @@ describe("getConfigsBaseForTypescript", () => {
 
   describe("typescript with react, next, storybook, jest", () => {
     const result = getConfigsBaseForTypescript(["next", "react", "storybook", "jest"])
-    it("getConfigsBaseForTypescript の戻り値は配列長19", () => {
-      expect(result).toHaveLength(19)
+    it("getConfigsBaseForTypescript の戻り値は配列長20", () => {
+      expect(result).toHaveLength(20)
     })
     it.each([
       [0, "eslint-config-sc-ts/initialRecord"],
       [1, "eslint-config-sc-ts/importRecommendedRecord"],
-      [2, "eslint-config-sc-ts/eslintRecommendedRecord"],
-      [3, "eslint-config-sc-ts/unicornRecommendedRecords"],
-      [4, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
-      [5, "eslint-config-sc-next/nextRecord"],
-      [6, "eslint-config-sc-react/initialRecord"],
-      [7, "eslint-config-sc-react/airbnbRecords"],
-      [8, "eslint-config-sc-react/reactRecords"],
-      [9, "eslint-config-sc-react/scJsCustomRecord"],
-      [10, "eslint-config-sc-ts/scJsCustomRecord"],
-      [11, "eslint-config-sc-ts/customRecord"],
-      [12, "eslint-config-sc-react/customRecord"],
-      [13, "eslint-config-sc-react/customRecordWithTypescript"],
-      [14, "eslint-config-sc-storybook/storybookConfigRecords"],
-      [15, "eslint-config-sc-storybook/overrideTypescriptRecord"],
-      [16, "eslint-config-sc-jest/jestPluginRecords"],
-      [17, "eslint-config-sc-jest/customRecord"],
-      [18, "eslint-config-sc-jest/overrideTypescriptRecord"],
+      [2, "eslint-config-sc-ts/promiseRecommendedRecord"],
+      [3, "eslint-config-sc-ts/eslintRecommendedRecord"],
+      [4, "eslint-config-sc-ts/unicornRecommendedRecords"],
+      [5, "eslint-config-sc-ts/typescriptEslintStrictTypeCheckedRecords"],
+      [6, "eslint-config-sc-next/nextRecord"],
+      [7, "eslint-config-sc-react/initialRecord"],
+      [8, "eslint-config-sc-react/airbnbRecords"],
+      [9, "eslint-config-sc-react/reactRecords"],
+      [10, "eslint-config-sc-react/scJsCustomRecord"],
+      [11, "eslint-config-sc-ts/scJsCustomRecord"],
+      [12, "eslint-config-sc-ts/customRecord"],
+      [13, "eslint-config-sc-react/customRecord"],
+      [14, "eslint-config-sc-react/customRecordWithTypescript"],
+      [15, "eslint-config-sc-storybook/storybookConfigRecords"],
+      [16, "eslint-config-sc-storybook/overrideTypescriptRecord"],
+      [17, "eslint-config-sc-jest/jestPluginRecords"],
+      [18, "eslint-config-sc-jest/customRecord"],
+      [19, "eslint-config-sc-jest/overrideTypescriptRecord"],
     ] as const)("%i番目の config の name は「%s」", (index, name) => {
       expect(getConfigName(result[index])).toBe(name)
     })

--- a/packages/eslint-config-all/src/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForJavascript/index.ts
+++ b/packages/eslint-config-all/src/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForJavascript/index.ts
@@ -14,6 +14,7 @@ export const getConfigsBaseForJavascript: GetConfigsBaseForJavascript = (librari
   configBase.push(
     jsConfig.configs.initialRecord,
     jsConfig.configs.importRecommendedRecord,
+    jsConfig.configs.promiseRecommendedRecord,
     jsConfig.configs.eslintRecommendedRecord,
     jsConfig.configs.unicornRecommendedRecords,
   )

--- a/packages/eslint-config-all/src/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForTypescript/index.ts
+++ b/packages/eslint-config-all/src/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForTypescript/index.ts
@@ -14,6 +14,7 @@ export const getConfigsBaseForTypescript: GetConfigsBaseForTypescript = (librari
   configBase.push(
     tsConfig.configs.initialRecord,
     tsConfig.configs.importRecommendedRecord,
+    tsConfig.configs.promiseRecommendedRecord,
     tsConfig.configs.eslintRecommendedRecord,
     tsConfig.configs.unicornRecommendedRecords,
     tsConfig.configs.typescriptEslintStrictTypeCheckedRecords,

--- a/packages/eslint-config-js/package.json
+++ b/packages/eslint-config-js/package.json
@@ -51,6 +51,7 @@
     "eslint": "^9.30.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-promise": "^7.3.0",
     "fixpack": "^4.0.0",
     "npm-run-all2": "^9.0.2",
     "prettier": "^3.9.6",
@@ -62,6 +63,7 @@
     "@eslint/eslintrc": ">=3.3.1",
     "@eslint/js": ">=9.30.0",
     "eslint-plugin-import": ">=2.32.0",
+    "eslint-plugin-promise": ">=7.3.0",
     "eslint-plugin-unicorn": ">=59.0.1"
   }
 }

--- a/packages/eslint-config-js/src/flatConfig/index.ts
+++ b/packages/eslint-config-js/src/flatConfig/index.ts
@@ -3,6 +3,7 @@ import { customRecord } from "../shared/config/records/customRecord"
 import { eslintRecommendedRecord } from "../shared/config/records/eslintRecommendedRecord"
 import { importRecommendedRecord } from "../shared/config/records/importRecommendedRecord"
 import { initialRecord } from "../shared/config/records/initialRecord"
+import { promiseRecommendedRecord } from "../shared/config/records/promiseRecommendedRecord"
 import { unicornRecommendedRecords } from "../shared/config/records/unicornRecommendedRecords"
 
 import type { EslintFlatConfig } from "../libs/shared-for-config/types/EslintFlatConfig"
@@ -10,6 +11,7 @@ import type { EslintFlatConfig } from "../libs/shared-for-config/types/EslintFla
 export const flatConfig = [
   initialRecord,
   importRecommendedRecord,
+  promiseRecommendedRecord,
   eslintRecommendedRecord,
   unicornRecommendedRecords,
   airbnbBaseRecords,

--- a/packages/eslint-config-js/src/index.ts
+++ b/packages/eslint-config-js/src/index.ts
@@ -4,6 +4,7 @@ import { customRecord } from "./shared/config/records/customRecord"
 import { eslintRecommendedRecord } from "./shared/config/records/eslintRecommendedRecord"
 import { importRecommendedRecord } from "./shared/config/records/importRecommendedRecord"
 import { initialRecord } from "./shared/config/records/initialRecord"
+import { promiseRecommendedRecord } from "./shared/config/records/promiseRecommendedRecord"
 import { unicornRecommendedRecords } from "./shared/config/records/unicornRecommendedRecords"
 import { PACKAGE_NAME } from "./shared/constants/PACKAGE_NAME"
 
@@ -21,6 +22,7 @@ const plugin = {
     eslintRecommendedRecord,
     importRecommendedRecord,
     initialRecord,
+    promiseRecommendedRecord,
     unicornRecommendedRecords,
 
     customRecord,

--- a/packages/eslint-config-js/src/shared/config/records/promiseRecommendedRecord/index.ts
+++ b/packages/eslint-config-js/src/shared/config/records/promiseRecommendedRecord/index.ts
@@ -1,0 +1,12 @@
+import { PACKAGE_NAME } from "../../../constants/PACKAGE_NAME"
+
+import type { EslintFlatConfig } from "../../../../libs/shared-for-config/types/EslintFlatConfig"
+
+// cjs 形式のため
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const eslintPluginPromise = require("eslint-plugin-promise")
+
+export const promiseRecommendedRecord = {
+  ...eslintPluginPromise.configs["flat/recommended"],
+  name: `${PACKAGE_NAME}/promiseRecommendedRecord`,
+} as const satisfies EslintFlatConfig

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -57,6 +57,7 @@
     "eslint-config-sc-js": "workspace:^",
     "eslint-config-sc-ts": "workspace:^",
     "eslint-plugin-jsx-a11y": "^6.10.2",
+    "eslint-plugin-react": "^7.37.5",
     "fixpack": "^4.0.0",
     "npm-run-all2": "^9.0.2",
     "prettier": "^3.9.6",
@@ -67,6 +68,7 @@
   "peerDependencies": {
     "eslint-config-sc-js": ">=0.1.3 <1",
     "eslint-config-sc-ts": ">=0.1.2 <1",
-    "eslint-plugin-jsx-a11y": ">=6.10.2"
+    "eslint-plugin-jsx-a11y": ">=6.10.2",
+    "eslint-plugin-react": ">=7.37.5"
   }
 }

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -58,6 +58,7 @@
     "eslint-config-sc-ts": "workspace:^",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "fixpack": "^4.0.0",
     "npm-run-all2": "^9.0.2",
     "prettier": "^3.9.6",
@@ -69,6 +70,7 @@
     "eslint-config-sc-js": ">=0.1.3 <1",
     "eslint-config-sc-ts": ">=0.1.2 <1",
     "eslint-plugin-jsx-a11y": ">=6.10.2",
-    "eslint-plugin-react": ">=7.37.5"
+    "eslint-plugin-react": ">=7.37.5",
+    "eslint-plugin-react-hooks": ">=7.1.1"
   }
 }

--- a/packages/eslint-config-react/src/shared/config/records/reactRecords/index.ts
+++ b/packages/eslint-config-react/src/shared/config/records/reactRecords/index.ts
@@ -7,5 +7,12 @@ export const reactRecords = [
   {
     name: `${PACKAGE_NAME}/reactRecords`,
   },
-  ...getCompatExtends("plugin:react/recommended", "plugin:react/jsx-runtime"),
+  ...getCompatExtends(
+    "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
+    // plugin:react-hooks/recommended を丸ごと採用している。React Compiler の設定・導入自体を
+    // 検証するルール (config, gating, preserve-manual-memoization) は Compiler の導入方針に
+    // 応じて適宜 OFF にすること。
+    "plugin:react-hooks/recommended",
+  ),
 ] as const satisfies EslintFlatConfig[]

--- a/packages/eslint-config-ts/src/flatConfig/index.ts
+++ b/packages/eslint-config-ts/src/flatConfig/index.ts
@@ -3,6 +3,7 @@ import { customRecord } from "../shared/config/records/customRecord"
 import { eslintRecommendedRecord } from "../shared/config/records/eslintRecommendedRecord"
 import { importRecommendedRecord } from "../shared/config/records/importRecommendedRecord"
 import { initialRecord } from "../shared/config/records/initialRecord"
+import { promiseRecommendedRecord } from "../shared/config/records/promiseRecommendedRecord"
 import { scJsCustomRecord } from "../shared/config/records/scJsCustomRecord"
 import { typescriptEslintStrictTypeCheckedRecords } from "../shared/config/records/typescriptEslintStrictTypeCheckedRecords"
 import { unicornRecommendedRecords } from "../shared/config/records/unicornRecommendedRecords"
@@ -12,6 +13,7 @@ import type { EslintFlatConfig } from "../libs/shared-for-config/types/EslintFla
 export const flatConfig = [
   initialRecord,
   importRecommendedRecord,
+  promiseRecommendedRecord,
   eslintRecommendedRecord,
   unicornRecommendedRecords,
   typescriptEslintStrictTypeCheckedRecords,

--- a/packages/eslint-config-ts/src/index.ts
+++ b/packages/eslint-config-ts/src/index.ts
@@ -4,6 +4,7 @@ import { customRecord } from "./shared/config/records/customRecord"
 import { eslintRecommendedRecord } from "./shared/config/records/eslintRecommendedRecord"
 import { importRecommendedRecord } from "./shared/config/records/importRecommendedRecord"
 import { initialRecord } from "./shared/config/records/initialRecord"
+import { promiseRecommendedRecord } from "./shared/config/records/promiseRecommendedRecord"
 import { scJsCustomRecord } from "./shared/config/records/scJsCustomRecord"
 import { typescriptEslintStrictTypeCheckedRecords } from "./shared/config/records/typescriptEslintStrictTypeCheckedRecords"
 import { unicornRecommendedRecords } from "./shared/config/records/unicornRecommendedRecords"
@@ -23,6 +24,7 @@ const plugin = {
     eslintRecommendedRecord,
     importRecommendedRecord,
     initialRecord,
+    promiseRecommendedRecord,
     scJsCustomRecord,
     typescriptEslintStrictTypeCheckedRecords,
     unicornRecommendedRecords,

--- a/packages/eslint-config-ts/src/shared/config/records/promiseRecommendedRecord/index.ts
+++ b/packages/eslint-config-ts/src/shared/config/records/promiseRecommendedRecord/index.ts
@@ -1,0 +1,10 @@
+import eslintConfigSCJs from "eslint-config-sc-js"
+
+import { PACKAGE_NAME } from "../../../constants/PACKAGE_NAME"
+
+import type { EslintFlatConfig } from "../../../../libs/shared-for-config/types/EslintFlatConfig"
+
+export const promiseRecommendedRecord = {
+  ...eslintConfigSCJs.configs.promiseRecommendedRecord,
+  name: `${PACKAGE_NAME}/promiseRecommendedRecord`,
+} as const satisfies EslintFlatConfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,6 +635,9 @@ importers:
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@9.39.4(jiti@2.6.1))
       fixpack:
         specifier: ^4.0.0
         version: 4.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.39.4(jiti@2.6.1))
@@ -290,7 +290,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
       fixpack:
         specifier: ^4.0.0
         version: 4.0.0
@@ -342,7 +342,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
       fixpack:
         specifier: ^4.0.0
         version: 4.0.0
@@ -444,7 +444,7 @@ importers:
     dependencies:
       eslint-plugin-jest:
         specifier: '>=29.0.1'
-        version: 29.15.1(@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7)))(typescript@5.9.3)
+        version: 29.15.1(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.27.7)))(typescript@5.9.3)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.6
@@ -521,7 +521,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
       fixpack:
         specifier: ^4.0.0
         version: 4.0.0
@@ -632,6 +632,9 @@ importers:
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react:
+        specifier: ^7.37.5
+        version: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       fixpack:
         specifier: ^4.0.0
         version: 4.0.0
@@ -787,7 +790,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
       fixpack:
         specifier: ^4.0.0
         version: 4.0.0
@@ -2095,9 +2098,6 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@25.8.0':
-    resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
-
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
@@ -2113,26 +2113,11 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@typescript-eslint/eslint-plugin@8.64.0':
-    resolution: {integrity: sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.64.0
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.65.0
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/parser@8.64.0':
-    resolution: {integrity: sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
@@ -2145,12 +2130,6 @@ packages:
 
   '@typescript-eslint/project-service@8.59.3':
     resolution: {integrity: sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.64.0':
-    resolution: {integrity: sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -2172,10 +2151,6 @@ packages:
     resolution: {integrity: sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.64.0':
-    resolution: {integrity: sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/scope-manager@8.65.0':
     resolution: {integrity: sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2186,23 +2161,10 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/tsconfig-utils@8.64.0':
-    resolution: {integrity: sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
   '@typescript-eslint/tsconfig-utils@8.65.0':
     resolution: {integrity: sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.64.0':
-    resolution: {integrity: sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/type-utils@8.65.0':
@@ -2216,22 +2178,12 @@ packages:
     resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.64.0':
-    resolution: {integrity: sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/types@8.65.0':
     resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.59.3':
     resolution: {integrity: sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/typescript-estree@8.64.0':
-    resolution: {integrity: sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -2249,13 +2201,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.64.0':
-    resolution: {integrity: sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
   '@typescript-eslint/utils@8.65.0':
     resolution: {integrity: sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2265,10 +2210,6 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.59.3':
     resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/visitor-keys@8.64.0':
-    resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.65.0':
@@ -4750,9 +4691,6 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
-
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
@@ -6272,11 +6210,6 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@25.8.0':
-    dependencies:
-      undici-types: 7.24.6
-    optional: true
-
   '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
@@ -6293,23 +6226,6 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.64.0
-      eslint: 9.39.4(jiti@2.6.1)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -6325,19 +6241,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -6359,16 +6262,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/project-service@8.64.0(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.64.0
-      debug: 4.4.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@typescript-eslint/project-service@8.65.0(typescript@5.9.3)':
     dependencies:
@@ -6398,12 +6291,6 @@ snapshots:
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/visitor-keys': 8.59.3
 
-  '@typescript-eslint/scope-manager@8.64.0':
-    dependencies:
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/visitor-keys': 8.64.0
-    optional: true
-
   '@typescript-eslint/scope-manager@8.65.0':
     dependencies:
       '@typescript-eslint/types': 8.65.0
@@ -6413,27 +6300,9 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
-    optional: true
-
   '@typescript-eslint/tsconfig-utils@8.65.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
-
-  '@typescript-eslint/type-utils@8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.6.1)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@typescript-eslint/type-utils@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -6448,9 +6317,6 @@ snapshots:
       - supports-color
 
   '@typescript-eslint/types@8.59.3': {}
-
-  '@typescript-eslint/types@8.64.0':
-    optional: true
 
   '@typescript-eslint/types@8.65.0': {}
 
@@ -6468,22 +6334,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/typescript-estree@8.64.0(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3
-      minimatch: 10.2.5
-      semver: 7.8.0
-      tinyglobby: 0.2.16
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@typescript-eslint/typescript-estree@8.65.0(typescript@5.9.3)':
     dependencies:
@@ -6511,18 +6361,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@typescript-eslint/utils@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
@@ -6538,12 +6376,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.59.3
       eslint-visitor-keys: 5.0.1
-
-  '@typescript-eslint/visitor-keys@8.64.0':
-    dependencies:
-      '@typescript-eslint/types': 8.64.0
-      eslint-visitor-keys: 5.0.1
-    optional: true
 
   '@typescript-eslint/visitor-keys@8.65.0':
     dependencies:
@@ -7536,33 +7368,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.10
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7573,37 +7394,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    optional: true
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7621,13 +7412,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@29.15.1(@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7)))(typescript@5.9.3):
+  eslint-plugin-jest@29.15.1(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(jest@30.4.2(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.27.7)))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      jest: 30.4.2(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7))
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      jest: 30.4.2(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.27.7))
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -8351,26 +8142,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7)):
-    dependencies:
-      '@jest/core': 30.4.2(esbuild-register@3.6.0(esbuild@0.27.7))
-      '@jest/test-result': 30.4.1
-      '@jest/types': 30.4.1
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7))
-      jest-util: 30.4.1
-      jest-validate: 30.4.1
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-    optional: true
-
   jest-cli@30.4.2(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.25.12)):
     dependencies:
       '@jest/core': 30.4.2(esbuild-register@3.6.0(esbuild@0.25.12))
@@ -8409,39 +8180,6 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
-
-  jest-config@30.4.2(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.4.0
-      '@jest/test-sequencer': 30.4.1
-      '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.4.2
-      jest-docblock: 30.4.0
-      jest-environment-node: 30.4.1
-      jest-regex-util: 30.4.0
-      jest-resolve: 30.4.1
-      jest-runner: 30.4.2
-      jest-util: 30.4.1
-      jest-validate: 30.4.1
-      parse-json: 5.2.0
-      pretty-format: 30.4.1
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.8.0
-      esbuild-register: 3.6.0(esbuild@0.27.7)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-    optional: true
 
   jest-config@30.4.2(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.25.12)):
     dependencies:
@@ -8723,20 +8461,6 @@ snapshots:
       jest-util: 30.4.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  jest@30.4.2(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7)):
-    dependencies:
-      '@jest/core': 30.4.2(esbuild-register@3.6.0(esbuild@0.27.7))
-      '@jest/types': 30.4.1
-      import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.27.7))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-    optional: true
 
   jest@30.4.2(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.25.12)):
     dependencies:
@@ -9660,9 +9384,6 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
-
-  undici-types@7.24.6:
-    optional: true
 
   undici-types@8.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+        version: 2.32.0(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.39.4(jiti@2.6.1))
@@ -290,7 +290,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+        version: 2.32.0(eslint@9.39.4(jiti@2.6.1))
       fixpack:
         specifier: ^4.0.0
         version: 4.0.0
@@ -342,7 +342,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+        version: 2.32.0(eslint@9.39.4(jiti@2.6.1))
       fixpack:
         specifier: ^4.0.0
         version: 4.0.0
@@ -521,7 +521,10 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-promise:
+        specifier: ^7.3.0
+        version: 7.3.0(eslint@9.39.4(jiti@2.6.1))
       fixpack:
         specifier: ^4.0.0
         version: 4.0.0
@@ -793,7 +796,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+        version: 2.32.0(eslint@9.39.4(jiti@2.6.1))
       fixpack:
         specifier: ^4.0.0
         version: 4.0.0
@@ -3110,6 +3113,12 @@ packages:
     engines: {node: '>=4.0'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+
+  eslint-plugin-promise@7.3.0:
+    resolution: {integrity: sha512-6uGiOR0INuujr6PEQmeSSP7GbIMJ/ebEXXiEzb/nOj68LknH5Pxzb/AbZivmr6VE6TkTE8rTjRK9zhKpK6HsRA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react-hooks@7.1.1:
     resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
@@ -7371,22 +7380,41 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7397,7 +7425,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7410,6 +7438,61 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    optional: true
+
+  eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -7455,6 +7538,11 @@ snapshots:
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
+
+  eslint-plugin-promise@7.3.0(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      eslint: 9.39.4(jiti@2.6.1)
 
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.6.1)):
     dependencies:


### PR DESCRIPTION
## 変更概要
- eslint-config-sc-react に eslint-plugin-react の peerDependencies 未宣言バグを修正
- eslint-config-sc-react に eslint-plugin-react-hooks の recommended を追加
- eslint-config-sc-js / eslint-config-sc-ts / eslint-config-sc-all に eslint-plugin-promise の recommended を追加
- 上記対応の過程で判明した eslint-config-sc-all 側の既存不具合（react-hooks/purity のサンプル未対応）を修正

## 背景 / 目的
既存の `eslint-config-sc-*` 群を見直したところ、以下の抜けが見つかった。

1. `eslint-config-sc-react` の `reactRecords` が `getCompatExtends` 経由で内部的に `eslint-plugin-react` を require しているにもかかわらず、`package.json` に依存として宣言されておらず、外部消費者環境では依存解決に失敗する実装バグだった。
2. Hooks の呼び出し順序違反や `useEffect` の依存配列漏れ等を静的に検出する `eslint-plugin-react-hooks` が導入されていなかった。
3. Promise の握りつぶし等を検出する `eslint-plugin-promise` が JS/TS いずれの config にも導入されていなかった。

いずれも「保守性・安全性を高め、書き方の差異を減らす」という strict-check の方針に沿って対応した。

## 変更内容
- `packages/eslint-config-react/package.json`: `eslint-plugin-react` を devDependencies/peerDependencies に追加
- `packages/eslint-config-react/src/shared/config/records/reactRecords/index.ts`: `getCompatExtends` に `plugin:react-hooks/recommended` を追加。React Compiler 向けルール（config, gating, preserve-manual-memoization）は Compiler の導入方針に応じて OFF にする旨をコメントで明記
- `packages/eslint-config-js/src/shared/config/records/promiseRecommendedRecord/index.ts`（新規）: `eslint-plugin-promise` の `flat/recommended` を追加し、`flatConfig`/公開 `configs` に組み込み
- `packages/eslint-config-ts/src/shared/config/records/promiseRecommendedRecord/index.ts`（新規）: js 側の `promiseRecommendedRecord` を1:1でラップ
- `packages/eslint-config-all/src/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForJavascript/ForTypescript/index.ts`: `promiseRecommendedRecord` の push を追加し、対応する既存 vitest テスト3ファイルをインデックスのシフトに合わせて更新
- `dry-run/dr-eslint-config-sc-all/sample/{js,ts}-next-jest-storybook/src/index.{jsx,tsx}`: react-hooks 追加により `eslint-config-sc-all` 経由で新たに発火するようになった `react-hooks/purity`（`Math.random()` の JSX 内使用）に disable コメントを追加

## 影響範囲
- `eslint-config-sc-react` / `eslint-config-sc-js` / `eslint-config-sc-ts` / `eslint-config-sc-all` を利用する全ての消費者
- `eslint-plugin-react-hooks`（recommended 全16ルール）・`eslint-plugin-promise`（recommended）が新たに有効化されるため、既存コードで新規の lint エラーが発生する可能性がある（破壊的変更寄りの挙動変化）

## 動作確認
- 各パッケージで `pnpm check-code`（bootstrap + lint + spell-check + type-check + dry-run [+ test]）が green であることを確認
- react-hooks: 一時サンプルで `rules-of-hooks`（severity 2）/`exhaustive-deps`（severity 1）が意図通り発火することを実測確認。`eslint-config-sc-next` の dry-run でもプラグイン未登録エラーが出ないことを確認
- promise: 一時サンプルで `promise/param-names` 等が `eslint-config-sc-js`/`eslint-config-sc-ts`/`eslint-config-sc-all` 経由でそれぞれ発火することを実測確認
- `eslint-config-sc-all` の vitest テスト（186件）が green、カバレッジ94.82%（75%要件を満たす）

## 補足
- react-hooks の恒久的な dry-run サンプル追加は見送った。上流の `recommended` を丸ごと採用する場合、個別ルールごとに恒久サンプルを網羅するのはキリがないという判断による
- react-hooks recommended には Hooks の基本ルール以外に「Rules of React」系の一般的な純粋性検証ルール（`purity`/`immutability`/`refs` 等）も含まれるため、既存コードベースで新たに lint エラーが出る可能性がある点に留意